### PR TITLE
Fix: 403 Forbidden Error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.discordbots</groupId>
+      <groupId>com.github.DiscordBotList</groupId>
       <artifactId>DBL-Java-Library</artifactId>
       <version>2.0.1</version>
     </dependency>
@@ -240,10 +240,6 @@
       <id>jcenter</id>
       <name>jcenter-bintray</name>
       <url>https://jcenter.bintray.com</url>
-    </repository>
-    <repository>
-      <id>sedmelluq-bintray</id>
-      <url>https://dl.bintray.com/sedmelluq/com.sedmelluq</url>
     </repository>
     <repository>
       <id>StringList</id>


### PR DESCRIPTION
I removed the sedmelluq-bintray repository and used the jitpack.io repository instead to use DBL-Java-Library by adjusting the dependency for it.

After that the installation `mvn clean install` went flawlessly