### PR TITLE
PlayableFactory#createPlayableForSpotifyUrlType: catch NotFoundException

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/audio/PlayableFactory.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/PlayableFactory.java
@@ -360,10 +360,10 @@ public class PlayableFactory {
         try {
             String accessToken = spotifyApi.clientCredentials().build().execute().getAccessToken();
             spotifyApi.setAccessToken(accessToken);
-            return loadFunc.apply(id);
+            return loadFunc.doApply(id);
         } catch (NotFoundException e) {
             throw new NoResultsFoundException(String.format("No Spotify track found for id '%s'", id));
-        } catch (IOException | SpotifyWebApiException | ParseException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Exception during Spotify request", e);
         } finally {
             spotifyApi.setAccessToken(null);


### PR DESCRIPTION
 - use CheckedFunction#doApply instead of #apply as #apply wraps checked
   exceptions into CommandRuntimeExceptions and NotFoundException is now
   a checked exception since the spotify api update, meaning the
   NotFoundException was not caught