### PR TITLE
fix potential connection leak in ForkTaskTreadPool

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/concurrent/ForkTaskTreadPool.java
+++ b/src/main/java/net/robinfriedli/aiode/concurrent/ForkTaskTreadPool.java
@@ -20,7 +20,11 @@ public class ForkTaskTreadPool extends AbstractExecutorService {
         ThreadContext forkedThreadContext = ThreadContext.Current.get().fork();
         threadPool.execute(() -> {
             ThreadContext.Current.installExplicitly(forkedThreadContext);
-            command.run();
+            try {
+                command.run();
+            } finally {
+                forkedThreadContext.clear();
+            }
         });
     }
 


### PR DESCRIPTION
 - when forking a ThreadContext with an ExecutionContext installed and
   executing a task that starts a transaction (e.g. when called by
   HollowYouTubeVideo#fetch), the opened session would not get closed
   after task completion as the ThreadContext wasn't cleared