### PR TITLE
enable configuration of yt cookies to enable age restricted videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ aiode.preferences.ipv6_blocks=
 aiode.tokens.discord_bot_id=
 #copy your top.gg token here
 aiode.tokens.topgg_token=
+###################
+# youtube cookies #
+###################
+# set these properties to support age restricted videos on YouTube, see https://github.com/Walkyst/lavaplayer-fork/issues/18
+aiode.tokens.yt-3PSID=
+aiode.tokens.yt-3PAPISID=
 ```
 #### 4.2 Adjust application.properties
 ##### 4.2.1 Review the datasource properties and make necessary adjustments. If you are using a local postgres server and name your database "aiode" you can leave it as it is. If you need help setting up your postgres server, please refer to their official documentation: http://www.postgresqltutorial.com/.

--- a/src/main/java/net/robinfriedli/aiode/audio/AudioManager.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/AudioManager.java
@@ -16,6 +16,7 @@ import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeHttpContextFilter;
 import com.sedmelluq.lava.extensions.youtuberotator.YoutubeIpRotatorSetup;
 import com.sedmelluq.lava.extensions.youtuberotator.planner.RotatingNanoIpRoutePlanner;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.IpBlock;
@@ -58,10 +59,14 @@ public class AudioManager extends AbstractShutdownable {
     private final Logger logger;
     private final YouTubeService youTubeService;
 
-    public AudioManager(GuildManager guildManager,
-                        HibernateComponent hibernateComponent,
-                        YouTubeService youTubeService,
-                        @Value("${aiode.preferences.ipv6_blocks}") String ipv6Blocks) {
+    public AudioManager(
+        GuildManager guildManager,
+        HibernateComponent hibernateComponent,
+        YouTubeService youTubeService,
+        @Value("${aiode.preferences.ipv6_blocks:#{null}}") String ipv6Blocks,
+        @Value("${aiode.tokens.yt-3PSID:#{null}}") String yt3Psid,
+        @Value("${aiode.tokens.yt-3PAPISID:#{null}}") String yt3Papisid
+    ) {
         playerManager = new DefaultAudioPlayerManager();
         audioTrackLoader = new AudioTrackLoader(playerManager);
 
@@ -90,6 +95,13 @@ public class AudioManager extends AbstractShutdownable {
             YoutubeIpRotatorSetup youtubeIpRotatorSetup = new YoutubeIpRotatorSetup(new RotatingNanoIpRoutePlanner(ipv6BlockList, ip -> true, true));
             youtubeIpRotatorSetup.forSource(youtubeAudioSourceManager).setup();
             logger.info("YouTubeIpRotator set up with block: " + ipv6Blocks);
+        }
+
+        if (!Strings.isNullOrEmpty(yt3Psid)) {
+            YoutubeHttpContextFilter.setPSID(yt3Psid);
+        }
+        if (!Strings.isNullOrEmpty(yt3Papisid)) {
+            YoutubeHttpContextFilter.setPAPISID(yt3Papisid);
         }
     }
 


### PR DESCRIPTION
 - add properties aiode.tokens.yt-3PSID and aiode.tokens.yt-3PAPISID to
   specify cookies used by the YoutubeHttpContextFilter to support age
   restricted videos
 - see https://github.com/Walkyst/lavaplayer-fork/issues/18