### PR TITLE
add multi instance operation support

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/Aiode.java
+++ b/src/main/java/net/robinfriedli/aiode/Aiode.java
@@ -39,6 +39,7 @@ import net.robinfriedli.aiode.scripting.GroovyVariableManager;
 import net.robinfriedli.aiode.servers.HttpServerManager;
 import net.robinfriedli.jxp.api.JxpBackend;
 import org.hibernate.SessionFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Component;
 import se.michaelthelin.spotify.SpotifyApi;
@@ -57,6 +58,8 @@ public class Aiode {
     private static volatile boolean shuttingDown;
 
     private static Aiode instance;
+
+    private final boolean mainInstance;
 
     private final AudioManager audioManager;
     private final CommandExecutionQueueManager executionQueueManager;
@@ -83,30 +86,34 @@ public class Aiode {
     private final VersionManager versionManager;
     private final WidgetManager widgetManager;
 
-    public Aiode(AudioManager audioManager,
-                 CommandExecutionQueueManager executionQueueManager,
-                 CommandManager commandManager,
-                 ConfigurableApplicationContext springBootContext,
-                 CronJobService cronJobService,
-                 ExceptionHandlerRegistry exceptionHandlerRegistry,
-                 GroovySandboxComponent groovySandboxComponent,
-                 GroovyVariableManager groovyVariableManager,
-                 GuildManager guildManager,
-                 GuildPropertyManager guildPropertyManager,
-                 HibernateComponent hibernateComponent,
-                 HttpServerManager httpServerManager,
-                 JxpBackend jxpBackend,
-                 LoginManager loginManager,
-                 MessageService messageService,
-                 QueryBuilderFactory queryBuilderFactory,
-                 SecurityManager securityManager,
-                 ShardManager shardManager,
-                 SpotifyApi.Builder spotifyApiBuilder,
-                 SpotifyComponent spotifyComponent,
-                 SpringPropertiesConfig springPropertiesConfig,
-                 VersionManager versionManager,
-                 WidgetManager widgetManager,
-                 ListenerAdapter... listeners) {
+    public Aiode(
+        @Value("${aiode.preferences.main_instance:true}") boolean mainInstance,
+        AudioManager audioManager,
+        CommandExecutionQueueManager executionQueueManager,
+        CommandManager commandManager,
+        ConfigurableApplicationContext springBootContext,
+        CronJobService cronJobService,
+        ExceptionHandlerRegistry exceptionHandlerRegistry,
+        GroovySandboxComponent groovySandboxComponent,
+        GroovyVariableManager groovyVariableManager,
+        GuildManager guildManager,
+        GuildPropertyManager guildPropertyManager,
+        HibernateComponent hibernateComponent,
+        HttpServerManager httpServerManager,
+        JxpBackend jxpBackend,
+        LoginManager loginManager,
+        MessageService messageService,
+        QueryBuilderFactory queryBuilderFactory,
+        SecurityManager securityManager,
+        ShardManager shardManager,
+        SpotifyApi.Builder spotifyApiBuilder,
+        SpotifyComponent spotifyComponent,
+        SpringPropertiesConfig springPropertiesConfig,
+        VersionManager versionManager,
+        WidgetManager widgetManager,
+        ListenerAdapter... listeners
+    ) {
+        this.mainInstance = mainInstance;
         this.audioManager = audioManager;
         this.executionQueueManager = executionQueueManager;
         this.commandManager = commandManager;
@@ -239,6 +246,10 @@ public class Aiode {
 
     public static boolean isShuttingDown() {
         return shuttingDown;
+    }
+
+    public boolean isMainInstance() {
+        return mainInstance;
     }
 
     public AudioManager getAudioManager() {

--- a/src/main/java/net/robinfriedli/aiode/boot/SpringBootstrap.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/SpringBootstrap.java
@@ -49,6 +49,10 @@ public class SpringBootstrap implements CommandLineRunner {
             InputStream startupTasksFile = getClass().getResourceAsStream("/xml-contributions/startupTasks.xml");
             Context context = jxpBackend.createContext(startupTasksFile);
             for (StartupTaskContribution element : context.getInstancesOf(StartupTaskContribution.class)) {
+                if (!aiode.isMainInstance() && element.getAttribute("mainInstanceOnly").getBool()) {
+                    continue;
+                }
+
                 if (!element.getAttribute("runForEachShard").getBool()) {
                     element.instantiate().runTask(null);
                 }

--- a/src/main/java/net/robinfriedli/aiode/boot/configurations/JdaComponent.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/configurations/JdaComponent.java
@@ -81,7 +81,7 @@ public class JdaComponent {
             }
 
             if (!Strings.isNullOrEmpty(shardRange)) {
-                String[] split = shardRange.split("\\w*-\\w*");
+                String[] split = shardRange.split("\\s*-\\s*");
                 if (split.length != 2) {
                     throw new IllegalArgumentException(String.format("Range '%s' is not formatted correctly", shardRange));
                 }

--- a/src/main/java/net/robinfriedli/aiode/boot/configurations/JdaComponent.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/configurations/JdaComponent.java
@@ -7,6 +7,7 @@ import javax.security.auth.login.LoginException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.sedmelluq.discord.lavaplayer.jdaudp.NativeAudioSendFactory;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.requests.GatewayIntent;
@@ -36,6 +37,10 @@ public class JdaComponent {
     private String discordToken;
     @Value("${aiode.preferences.native_audio_buffer}")
     private int nativeBufferDuration;
+    @Value("${aiode.preferences.shard_total:-1}")
+    private int shardTotal;
+    @Value("${aiode.preferences.shard_range:#{null}}")
+    private String shardRange;
 
     public JdaComponent(StartupListener startupListener) {
         this.startupListener = startupListener;
@@ -61,6 +66,7 @@ public class JdaComponent {
                 .setStatus(OnlineStatus.IDLE)
                 .setChunkingFilter(ChunkingFilter.NONE)
                 .setSessionController(new ConcurrentSessionController())
+                .setShardsTotal(shardTotal)
                 .addEventListeners(startupListener);
 
             if (nativeBufferDuration > 0) {
@@ -72,6 +78,17 @@ public class JdaComponent {
                 }
             } else {
                 logger.info("Native audio buffer disabled");
+            }
+
+            if (!Strings.isNullOrEmpty(shardRange)) {
+                String[] split = shardRange.split("\\w*-\\w*");
+                if (split.length != 2) {
+                    throw new IllegalArgumentException(String.format("Range '%s' is not formatted correctly", shardRange));
+                }
+
+                int minShard = Integer.parseInt(split[0].trim());
+                int maxShard = Integer.parseInt(split[1].trim());
+                shardManagerBuilder.setShards(minShard, maxShard);
             }
 
             return shardManagerBuilder.build();

--- a/src/main/java/net/robinfriedli/aiode/boot/tasks/ResetOutdatedYouTubeQuotaTask.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/tasks/ResetOutdatedYouTubeQuotaTask.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import javax.annotation.Nullable;
+import javax.persistence.LockModeType;
 
 import net.dv8tion.jda.api.JDA;
 import net.robinfriedli.aiode.audio.youtube.YouTubeService;
@@ -36,7 +37,7 @@ public class ResetOutdatedYouTubeQuotaTask implements StartupTask {
     @Override
     public void perform(@Nullable JDA shard) {
         StaticSessionProvider.consumeSession(session -> {
-            CurrentYouTubeQuotaUsage currentQuotaUsage = YouTubeService.getCurrentQuotaUsage(session);
+            CurrentYouTubeQuotaUsage currentQuotaUsage = YouTubeService.getCurrentQuotaUsage(session, LockModeType.PESSIMISTIC_WRITE);
             LocalDateTime lastUpdatedNoZone = currentQuotaUsage.getLastUpdated();
 
             if (lastUpdatedNoZone != null) {

--- a/src/main/java/net/robinfriedli/aiode/command/commands/admin/YouTubeQuotaCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/admin/YouTubeQuotaCommand.java
@@ -1,5 +1,7 @@
 package net.robinfriedli.aiode.command.commands.admin;
 
+import javax.persistence.LockModeType;
+
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.robinfriedli.aiode.Aiode;
 import net.robinfriedli.aiode.audio.youtube.YouTubeService;
@@ -18,7 +20,7 @@ public class YouTubeQuotaCommand extends AbstractAdminCommand {
     public void runAdmin() {
         YouTubeService youTubeService = Aiode.get().getAudioManager().getYouTubeService();
         int atomic = youTubeService.getAtomicQuotaUsage();
-        int persistent = YouTubeService.getCurrentQuotaUsage(getContext().getSession()).getQuota();
+        int persistent = YouTubeService.getCurrentQuotaUsage(getContext().getSession(), LockModeType.NONE).getQuota();
         int limit = Aiode.get().getSpringPropertiesConfig().requireApplicationProperty(Integer.class, "aiode.preferences.youtube_api_daily_quota");
 
         EmbedBuilder embedBuilder = new EmbedBuilder();

--- a/src/main/java/net/robinfriedli/aiode/command/commands/general/AnalyticsCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/general/AnalyticsCommand.java
@@ -4,12 +4,14 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.List;
 
+import com.google.common.base.Strings;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.sharding.ShardManager;
 import net.robinfriedli.aiode.Aiode;
 import net.robinfriedli.aiode.audio.AudioManager;
 import net.robinfriedli.aiode.audio.AudioPlayback;
+import net.robinfriedli.aiode.boot.SpringPropertiesConfig;
 import net.robinfriedli.aiode.command.AbstractCommand;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.CommandManager;
@@ -36,6 +38,7 @@ public class AnalyticsCommand extends AbstractCommand {
         Aiode aiode = Aiode.get();
         AudioManager audioManager = aiode.getAudioManager();
         GuildManager guildManager = aiode.getGuildManager();
+        SpringPropertiesConfig springPropertiesConfig = aiode.getSpringPropertiesConfig();
         Session session = getContext().getSession();
         Runtime runtime = Runtime.getRuntime();
 
@@ -68,6 +71,12 @@ public class AnalyticsCommand extends AbstractCommand {
         embedBuilder.addField("Saved tracks", String.valueOf(trackCount), true);
         embedBuilder.addField("Total tracks played", String.valueOf(playedCount), true);
         embedBuilder.addField("Thread count", String.format("%d (%d daemons)", threadCount, daemonThreadCount), true);
+
+        String shardRange = springPropertiesConfig.getApplicationProperty("aiode.preferences.shard_range");
+        if (!Strings.isNullOrEmpty(shardRange)) {
+            embedBuilder.addField("Shards", shardRange, true);
+        }
+
         embedBuilder.addField("Memory (in MB)",
             "Total: " + maxMemory + System.lineSeparator() +
                 "Allocated: " + allocatedMemory + System.lineSeparator() +

--- a/src/main/java/net/robinfriedli/aiode/cron/tasks/ResetCurrentYouTubeQuotaTask.java
+++ b/src/main/java/net/robinfriedli/aiode/cron/tasks/ResetCurrentYouTubeQuotaTask.java
@@ -1,5 +1,7 @@
 package net.robinfriedli.aiode.cron.tasks;
 
+import javax.persistence.LockModeType;
+
 import org.slf4j.LoggerFactory;
 
 import net.robinfriedli.aiode.Aiode;
@@ -20,7 +22,7 @@ public class ResetCurrentYouTubeQuotaTask extends AbstractCronTask {
     protected void run(JobExecutionContext jobExecutionContext) {
         YouTubeService youTubeService = Aiode.get().getAudioManager().getYouTubeService();
         StaticSessionProvider.consumeSession(session -> {
-            CurrentYouTubeQuotaUsage currentQuotaUsage = YouTubeService.getCurrentQuotaUsage(session);
+            CurrentYouTubeQuotaUsage currentQuotaUsage = YouTubeService.getCurrentQuotaUsage(session, LockModeType.PESSIMISTIC_WRITE);
             youTubeService.setAtomicQuotaUsage(0);
             currentQuotaUsage.setQuota(0);
         });

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -79,6 +79,21 @@
       "name": "aiode.preferences.native_audio_buffer",
       "type": "java.lang.Integer",
       "description": "The amount of milliseconds of audio to buffer and stream using native code to avoid stutters caused by garbage collection activity. Ignored if not on Linux / Windows and amd64 / x86 and disabled if 0."
+    },
+    {
+      "name": "aiode.preferences.shard_total",
+      "type": "java.lang.Integer",
+      "description": "The total number of gateway shards, -1 means the total will be fetched from discord automatically, shard_range is not supported in that case."
+    },
+    {
+      "name": "aiode.preferences.shard_range",
+      "type": "java.lang.String",
+      "description": "Range of shards this node should launch, can't be set if shard_total is -1, includes both endpoints of the range, e.g. \"0-15\"."
+    },
+    {
+      "name": "aiode.preferences.main_instance",
+      "type": "java.lang.Boolean",
+      "description": "Determines if this bot instance is the main instance and will not run certain startup tasks or cron jobs otherwise. Should only be false in a multi instance environment, there should be exactly one main_instance."
     }
   ]
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,13 @@ aiode.preferences.spotify_market=US
 # ignored if not on Linux / Windows and amd64 / x86
 # disabled if 0
 aiode.preferences.native_audio_buffer=400
+# the total number of gateway shards, -1 means the total will be fetched from discord automatically, shard_range is not supported in that case
+aiode.preferences.shard_total=-1
+# range of shards this node should launch, can't be set if shard_total is -1, includes both endpoints of the range, e.g. "0-15"
+aiode.preferences.shard_range=
+# determines if this bot instance is the main instance and will not run certain startup tasks or cron jobs otherwise,
+# should only be false in a multi instance environment, there should be exactly one main_instance
+aiode.preferences.main_instance=true
 ##############
 # datasource #
 ##############

--- a/src/main/resources/schemas/cronJobSchema.xsd
+++ b/src/main/resources/schemas/cronJobSchema.xsd
@@ -12,6 +12,14 @@
     <xs:attribute name="cron" type="xs:string"/>
     <xs:attribute name="timeZone" type="xs:string"/>
     <xs:attribute name="implementation" type="xs:string"/>
+    <xs:attribute name="mainInstanceOnly" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Whether this task should only run on the main instance, see application property
+          aiode.preferences.main_instance.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
 </xs:schema>

--- a/src/main/resources/schemas/startupTaskSchema.xsd
+++ b/src/main/resources/schemas/startupTaskSchema.xsd
@@ -10,6 +10,14 @@
   <xs:complexType name="startupTask">
     <xs:attribute name="runForEachShard" type="xs:boolean"/>
     <xs:attribute name="implementation" type="xs:string"/>
+    <xs:attribute name="mainInstanceOnly" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Whether this task should only run on the main instance, see application property
+          aiode.preferences.main_instance. Only applicable to tasks where runForEachShard is false.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
 </xs:schema>

--- a/src/main/resources/xml-contributions/cronJobs.xml
+++ b/src/main/resources/xml-contributions/cronJobs.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <cronJobs xmlns="cronJobSpace">
   <cronJob id="playbackCleanup" cron="0 */3 * * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.PlaybackCleanupTask"/>
-  <cronJob id="spotifyRedirectIndexRefresh" cron="0 0 3 * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.RefreshSpotifyRedirectIndicesTask"/>
+  <cronJob id="spotifyRedirectIndexRefresh" cron="0 0 3 * * ? *" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.cron.tasks.RefreshSpotifyRedirectIndicesTask"/>
   <cronJob id="clearAbandonedGuildContexts" cron="0 */3 * * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.ClearAbandonedGuildContextsTask"/>
   <cronJob id="deleteGrantedRolesForDeletedRoles" cron="0 0 */1 * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.DeleteGrantedRolesForDeletedRolesTask"/>
-  <cronJob id="resetCurrentYouTubeQuota" cron="0 0 0 * * ? *" timeZone="PST" implementation="net.robinfriedli.aiode.cron.tasks.ResetCurrentYouTubeQuotaTask"/>
+  <cronJob id="resetCurrentYouTubeQuota" cron="0 0 0 * * ? *" timeZone="PST" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.cron.tasks.ResetCurrentYouTubeQuotaTask"/>
 </cronJobs>

--- a/src/main/resources/xml-contributions/startupTasks.xml
+++ b/src/main/resources/xml-contributions/startupTasks.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <startupTasks xmlns="startupTaskSpace">
   <startupTask runForEachShard="true" implementation="net.robinfriedli.aiode.boot.tasks.MigrateGuildSpecificationsTask"/>
-  <startupTask runForEachShard="false" implementation="net.robinfriedli.aiode.boot.tasks.CreatePermissionAccessConfigurationTask"/>
+  <startupTask runForEachShard="false" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.boot.tasks.CreatePermissionAccessConfigurationTask"/>
   <startupTask runForEachShard="false" implementation="net.robinfriedli.aiode.boot.tasks.SetRedirectedSpotifyTrackNameTask"/>
   <startupTask runForEachShard="true" implementation="net.robinfriedli.aiode.boot.tasks.MigratePlaylistsTask"/>
   <startupTask runForEachShard="true" implementation="net.robinfriedli.aiode.boot.tasks.VersionUpdateAlertTask"/>
-  <startupTask runForEachShard="false" implementation="net.robinfriedli.aiode.boot.tasks.SetPlaylistItemIndexTask"/>
-  <startupTask runForEachShard="false" implementation="net.robinfriedli.aiode.boot.tasks.ResetOutdatedYouTubeQuotaTask"/>
+  <startupTask runForEachShard="false" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.boot.tasks.SetPlaylistItemIndexTask"/>
+  <startupTask runForEachShard="false" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.boot.tasks.ResetOutdatedYouTubeQuotaTask"/>
   <startupTask runForEachShard="false" implementation="net.robinfriedli.aiode.boot.tasks.InitialiseCommandContributionsTask"/>
 </startupTasks>


### PR DESCRIPTION
 - add properties to specify which shards to launch and to declare a
   main instance
 - adjust youtube quota management to work with multiple instances by
   introducing pessimistic locking and synchronising the local value
   with the persistent value
 - add mainInstanceOnly attribute to startup tasks and cron jobs to
   declare tasks that should only run on the main instance
 - show shard range in AnalyticsCommand