### PR TITLE
implement global rate limiting for message dispatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,14 @@ dependencies {
     liquibaseRuntime sourceSets.main.runtimeClasspath
     liquibaseRuntime sourceSets.main.output
 
+    testImplementation "org.testng:testng:7.5"
+    testImplementation "com.google.truth:truth:1.1.3"
+
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:2.4.5"
+}
+
+test {
+    useTestNG()
 }
 
 group = "aiode"

--- a/src/test/java/net/robinfriedli/aiode/function/modes/RecursionPreventionModeTest.java
+++ b/src/test/java/net/robinfriedli/aiode/function/modes/RecursionPreventionModeTest.java
@@ -1,0 +1,17 @@
+package net.robinfriedli.aiode.function.modes;
+
+import org.testng.annotations.*;
+
+import net.robinfriedli.exec.BaseInvoker;
+import net.robinfriedli.exec.Mode;
+
+public class RecursionPreventionModeTest {
+
+    @Test
+    public void testNoRecurse() {
+        RecursionPreventionMode recursionPreventionMode = new RecursionPreventionMode("test");
+
+        new BaseInvoker().invoke(Mode.create().with(recursionPreventionMode), this::testNoRecurse);
+    }
+
+}


### PR DESCRIPTION
 - refactor RecursionPreventionMode to use ThreadContext instead of
   ThreadLocal as the ThreadContext is inherited by other threads in
   case the RateLimitInvoker delegates execution to a different thread
 - add unit test for RecursionPreventionMode