### PR TITLE
refactor new AudioQueue implementation

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/audio/QueueIterator.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/QueueIterator.java
@@ -204,9 +204,6 @@ public class QueueIterator extends AudioEventAdapter {
         if (!queue.getRepeatOne() || ignoreRepeat) {
             if (queue.hasNext(ignoreRepeat)) {
                 queue.iterate();
-                if (!queue.hasNext(true) && queue.getRepeatAll() && queue.isShuffle()) {
-                    queue.randomize();
-                }
                 playNext();
             } else {
                 queue.reset();

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/PlayableContainerQueueFragment.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/PlayableContainerQueueFragment.kt
@@ -114,6 +114,17 @@ class PlayableContainerQueueFragment(
         }
     }
 
+    override fun getPlayableInFracture(fractureIdx: Int, idx: Int): Playable {
+        val (start, end) = getFractureRange(fractureIdx)
+        val absoluteIdx = start + idx
+
+        if (absoluteIdx >= end) {
+            throw IndexOutOfBoundsException("Index $idx out of bounds for fracture of size ${end - start}")
+        }
+
+        return getPlayablesInCurrentOrder()[absoluteIdx]
+    }
+
     override fun getPlayablesInFracture(fractureIdx: Int): List<Playable> {
         val (start, end) = getFractureRange(fractureIdx)
         return getPlayablesInCurrentOrder().subList(start, end)
@@ -194,7 +205,7 @@ class PlayableContainerQueueFragment(
         for (i in 0 until randomFractureCount) {
             // values returned by the same generator are likely unique, occasional duplicate values are not a problem,
             // just means fewer fractures than randomFractureCount
-            fractures.add(random.nextInt(size))
+            fractures.add((random.nextInt(size) + 1).coerceAtMost(size - 1))
         }
 
         return fractures.size
@@ -212,7 +223,11 @@ class PlayableContainerQueueFragment(
     }
 
     override fun reduceToCurrentPlayable(): SinglePlayableQueueFragment {
-        return SinglePlayableQueueFragment(queue, playables[currentIndex], SinglePlayableContainer(playables[currentIndex]))
+        return if (randomOrder != null) {
+            SinglePlayableQueueFragment(queue, playables[randomOrder!![currentIndex]], SinglePlayableContainer(playables[randomOrder!![currentIndex]]))
+        } else {
+            SinglePlayableQueueFragment(queue, playables[currentIndex], SinglePlayableContainer(playables[currentIndex]))
+        }
     }
 
     private fun getFractureRange(fractureIdx: Int): Pair<Int, Int> {

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/QueueFragment.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/QueueFragment.kt
@@ -80,6 +80,11 @@ interface QueueFragment {
     fun getPlayablesInCurrentOrder(): List<Playable>
 
     /**
+     * @return the Playable at the given index within the given fracture
+     */
+    fun getPlayableInFracture(fractureIdx: Int, idx: Int): Playable
+
+    /**
      * @return the Playables within the given fracture, each fragment at least has one fracture at index 0
      */
     fun getPlayablesInFracture(fractureIdx: Int): List<Playable>

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/SinglePlayableQueueFragment.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/SinglePlayableQueueFragment.kt
@@ -11,22 +11,11 @@ class SinglePlayableQueueFragment(
     private val playableContainer: AbstractSinglePlayableContainer<*>
 ) : QueueFragment {
 
-    private var played: Boolean = false
-
     override fun currentIndex(): Int {
-        return if (played) {
-            0
-        } else {
-            -1
-        }
+        return 0
     }
 
     override fun next(): Playable {
-        if (played) {
-            throw IllegalStateException("${javaClass.simpleName} has no next element")
-        }
-
-        played = true
         return playable
     }
 
@@ -38,7 +27,7 @@ class SinglePlayableQueueFragment(
         return if (fractureIdx > 0) {
             throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
         } else {
-            !played
+            false
         }
     }
 
@@ -46,25 +35,16 @@ class SinglePlayableQueueFragment(
         return if (fractureIdx > 0) {
             throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
         } else {
-            played
+            false
         }
     }
 
     override fun previous(): Playable {
-        if (!played) {
-            throw IllegalStateException("${javaClass.simpleName} has no previous element")
-        }
-
-        played = false
         return playable
     }
 
-    override fun peekNext(): Playable? {
-        return if (played) {
-            null
-        } else {
-            playable
-        }
+    override fun peekNext(): Playable {
+        return playable
     }
 
     override fun size(): Int {
@@ -95,6 +75,16 @@ class SinglePlayableQueueFragment(
         return getPlayables()
     }
 
+    override fun getPlayableInFracture(fractureIdx: Int, idx: Int): Playable {
+        return if (fractureIdx > 0) {
+            throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
+        } else if (idx > 0) {
+            throw IndexOutOfBoundsException("Playable index $idx out of bounds for ${javaClass.simpleName}")
+        } else {
+            playable
+        }
+    }
+
     override fun getPlayablesInFracture(fractureIdx: Int): List<Playable> {
         return if (fractureIdx > 0) {
             throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
@@ -107,11 +97,7 @@ class SinglePlayableQueueFragment(
         return if (fractureIdx > 0) {
             throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
         } else {
-            if (played) {
-                Collections.emptyList()
-            } else {
-                getPlayables()
-            }
+            Collections.emptyList()
         }
     }
 
@@ -119,11 +105,7 @@ class SinglePlayableQueueFragment(
         return if (fractureIdx > 0) {
             throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
         } else {
-            if (!played) {
-                Collections.emptyList()
-            } else {
-                getPlayables()
-            }
+            Collections.emptyList()
         }
     }
 
@@ -144,21 +126,17 @@ class SinglePlayableQueueFragment(
     }
 
     override fun setPosition(fractureIdx: Int, offset: Int) {
-        return if (fractureIdx > 0) {
+        if (fractureIdx > 0) {
             throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
         } else if (offset > 0) {
             throw IndexOutOfBoundsException("Offset $offset out of bounds for ${javaClass.simpleName}")
-        } else {
-            played = true
         }
     }
 
     override fun resetPositionToStart() {
-        played = false
     }
 
     override fun resetPositionToEnd() {
-        played = true
     }
 
     override fun enableShuffle(protectCurrent: Boolean): Int {


### PR DESCRIPTION
 - adjust SinglePlayableQueueFragment
   - remove "played" flag as its implementation was overcomplicated and unreliable when listing the next or previous track - instead, change implementations of hasNext and hasPrevious to always return false, next and previous to always return the single track and change getNext- and getPreviousPlayablesInFracture to always return an empty list - change implementations of listNext and listPrev to only use getNextPlayables and getPreviousPlayables for the current node and use the new methods getPlayables(limit) and getLastPlayables(limit) for other nodes instead to disregard the other node's position list SinglePlayableQueueFragments
 - increment currIdx when inserting elements ahead of it
 - fix setting correct position for fragment fractures on iterate or reverse
   - remove isFirstNodeForFragment and isLastNodeForFragment and implement setFragmentPositionToStartOfFracture and setFragmentPositionToEndOfFracture instead to set the position of the fragment to the start / end of a fracture when iterating / reversing to a node representing that fracture
 - fix peekNext and implement QueueNode#getPlayable(idx) to return the playable at the specified index within the QueueNode's fracture instead of modifying the fragments current position on seek
 - fix retainCurrent check in doClear to check the result from the relevant list if shuffle is enabled, instead of always checking the result from nodeList
 - remove legacy feature that re-shuffles queue when reaching the last track in a shuffled queue from QueueIterator