### PR TITLE
Remove thread locals explicitly to prevent memory leaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "org.springframework.boot" version "2.7.4"
     id "org.jetbrains.kotlin.jvm" version "1.6.20"
     id "org.liquibase.gradle" version "2.0.4"
+    id "org.sonarqube" version "3.4.0.2513"
 }
 
 repositories {

--- a/src/main/java/net/robinfriedli/aiode/concurrent/CompletableFutures.java
+++ b/src/main/java/net/robinfriedli/aiode/concurrent/CompletableFutures.java
@@ -23,6 +23,8 @@ public class CompletableFutures {
                 handle.accept(result, throwable);
             } catch (Exception e) {
                 errorConsumer.accept(e);
+            } finally {
+                ThreadContext.Current.remove();
             }
         }));
     }
@@ -39,6 +41,8 @@ public class CompletableFutures {
                 consumer.accept(result);
             } catch (Exception e) {
                 LOGGER.error("Error handling thenAccept consumer for completable future", e);
+            } finally {
+                ThreadContext.Current.remove();
             }
         }));
     }

--- a/src/main/java/net/robinfriedli/aiode/concurrent/ForkTaskThreadPool.java
+++ b/src/main/java/net/robinfriedli/aiode/concurrent/ForkTaskThreadPool.java
@@ -24,6 +24,7 @@ public class ForkTaskThreadPool extends AbstractExecutorService {
                 command.run();
             } finally {
                 forkedThreadContext.clear();
+                ThreadContext.Current.remove();
             }
         });
     }

--- a/src/main/java/net/robinfriedli/aiode/concurrent/ThreadContext.java
+++ b/src/main/java/net/robinfriedli/aiode/concurrent/ThreadContext.java
@@ -220,6 +220,12 @@ public class ThreadContext {
             get().clear();
         }
 
+        /**
+         * Should be called to free the ThreadLocal variable since the thread may be reused later. Since the thread is
+         * kept in a thread pool, the garbage collector cannot determine that the variable should be freed.
+         */
+        public static void remove() { THREAD_CONTEXT.remove(); }
+
         public static boolean isInstalled(Class<?> contextType) {
             return get().isInstalled(contextType);
         }

--- a/src/main/java/net/robinfriedli/aiode/function/RateLimitInvoker.java
+++ b/src/main/java/net/robinfriedli/aiode/function/RateLimitInvoker.java
@@ -155,6 +155,7 @@ public class RateLimitInvoker extends BaseInvoker {
                 throw e;
             } finally {
                 forkedThreadContext.clear();
+                ThreadContext.Current.remove();
             }
         }, delay, TimeUnit.NANOSECONDS);
     }


### PR DESCRIPTION
Fixes the following issue found by SonarQube.

![309357248_784160889465516_2245400665869897804_n](https://user-images.githubusercontent.com/34945306/192874483-63785fdc-3489-4a2a-8b44-6ef1b48ab553.png)

![307576280_832867274554961_2900322971691580828_n](https://user-images.githubusercontent.com/34945306/192874507-5bd8d40f-ca8c-4172-9357-4cc251f9c7dd.png)
