### PR TITLE
Fix optional missing guard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "org.springframework.boot" version "2.7.4"
     id "org.jetbrains.kotlin.jvm" version "1.6.20"
     id "org.liquibase.gradle" version "2.0.4"
+    id "org.sonarqube" version "3.4.0.2513"
 }
 
 repositories {


### PR DESCRIPTION
## SonarQube Report
Fixed the following bug found by SonarQube:
![optionalBug_where](https://user-images.githubusercontent.com/29316659/192916525-517ff88a-2fe6-49ea-b1a8-7b2846388ae9.png)

![optionalBug_why](https://user-images.githubusercontent.com/29316659/192916411-b9188a78-18f5-414c-ba8b-6cf0843e65b5.png)

## Description
According to SonarQube, an unguarded optional is returned by either of:
- `HashMultimap.get(<int>)`                   -> This is impossible as the key is generated from the map's keys themselves
- `Collection.stream()`                               -> Which returns a stream (of optional values, but the stream isn't optional itself)
- `Stream.max(<Comparing_Function>) `                     

As described by SonarQube, there are usually a few ways around this type of problem. A few points about the chosen approach:

- In this case, the direct return structure of the method can't really be maintained as optional guards such as `ifPresent(<lambda_function>)` have `void` return types.  
- `getBestResult()`  now throws a `NoSpotifyResultsFoundException`. This is backward compatible with the rest of the codebase as the only place  `getBestResult()`  is called is here, and that method throws the more general `Exception` itself.
- Given the explicit `SurpressWarning()` that was present beforehand, it is likely that the author intended that an exception such as the one added by this commit shall never need to be triggered. The new code is definitely less readable than the old one, so whether this change is actually worth it or now is up for debate.
