### PR TITLE
overhaul charts command

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/Aiode.java
+++ b/src/main/java/net/robinfriedli/aiode/Aiode.java
@@ -18,6 +18,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.sharding.ShardManager;
 import net.robinfriedli.aiode.audio.AudioManager;
+import net.robinfriedli.aiode.audio.ChartService;
 import net.robinfriedli.aiode.audio.playables.PlayableContainerManager;
 import net.robinfriedli.aiode.boot.Shutdownable;
 import net.robinfriedli.aiode.boot.SpringPropertiesConfig;
@@ -63,6 +64,7 @@ public class Aiode {
     private final boolean mainInstance;
 
     private final AudioManager audioManager;
+    private final ChartService chartService;
     private final CommandExecutionQueueManager executionQueueManager;
     private final CommandManager commandManager;
     private final ConfigurableApplicationContext springBootContext;
@@ -91,6 +93,7 @@ public class Aiode {
     public Aiode(
         @Value("${aiode.preferences.main_instance:true}") boolean mainInstance,
         AudioManager audioManager,
+        ChartService chartService,
         CommandExecutionQueueManager executionQueueManager,
         CommandManager commandManager,
         ConfigurableApplicationContext springBootContext,
@@ -118,6 +121,7 @@ public class Aiode {
     ) {
         this.mainInstance = mainInstance;
         this.audioManager = audioManager;
+        this.chartService = chartService;
         this.executionQueueManager = executionQueueManager;
         this.commandManager = commandManager;
         this.springBootContext = springBootContext;
@@ -258,6 +262,10 @@ public class Aiode {
 
     public AudioManager getAudioManager() {
         return audioManager;
+    }
+
+    public ChartService getChartService() {
+        return chartService;
     }
 
     public CommandExecutionQueueManager getExecutionQueueManager() {

--- a/src/main/java/net/robinfriedli/aiode/audio/ChartService.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/ChartService.java
@@ -1,0 +1,283 @@
+package net.robinfriedli.aiode.audio;
+
+import java.math.BigInteger;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import net.robinfriedli.aiode.boot.configurations.HibernateComponent;
+import net.robinfriedli.aiode.entities.Artist;
+import net.robinfriedli.aiode.entities.GlobalArtistChart;
+import net.robinfriedli.aiode.entities.GlobalTrackChart;
+import net.robinfriedli.aiode.entities.PlaybackHistory;
+import net.robinfriedli.aiode.entities.PlaybackHistorySource;
+import net.robinfriedli.aiode.entities.SpotifyItemKind;
+import net.robinfriedli.aiode.entities.UserPlaybackHistory;
+import net.robinfriedli.aiode.persist.qb.QueryBuilderFactory;
+import net.robinfriedli.aiode.persist.qb.builders.SelectQueryBuilder;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChartService {
+
+    private final HibernateComponent hibernateComponent;
+    private final QueryBuilderFactory queryBuilderFactory;
+
+    public ChartService(HibernateComponent hibernateComponent, QueryBuilderFactory queryBuilderFactory) {
+        this.hibernateComponent = hibernateComponent;
+        this.queryBuilderFactory = queryBuilderFactory;
+    }
+
+    public void refreshPersistentGlobalCharts() {
+        hibernateComponent.consumeSession(session -> {
+            session.createSQLQuery("delete from global_artist_chart").executeUpdate();
+            session.createSQLQuery("delete from global_track_chart").executeUpdate();
+
+            for (Object[] record : getGlobalTrackChart(session)) {
+                GlobalTrackChart globalTrackChart = new GlobalTrackChart();
+                globalTrackChart.setSource(session.get(PlaybackHistorySource.class, (long) record[0]));
+                globalTrackChart.setTrackId((String) record[1]);
+                globalTrackChart.setCount((long) record[2]);
+                Long spotifyItemKindPk = (Long) record[3];
+                if (spotifyItemKindPk != null) {
+                    globalTrackChart.setSpotifyItemKind(session.get(SpotifyItemKind.class, spotifyItemKindPk));
+                }
+                globalTrackChart.setMonthly(false);
+                session.save(globalTrackChart);
+            }
+
+            for (Object[] record : getGlobalTrackMonthlyChart(session)) {
+                GlobalTrackChart globalTrackChart = new GlobalTrackChart();
+                globalTrackChart.setSource(session.get(PlaybackHistorySource.class, (long) record[0]));
+                globalTrackChart.setTrackId((String) record[1]);
+                globalTrackChart.setCount((long) record[2]);
+                Long spotifyItemKindPk = (Long) record[3];
+                if (spotifyItemKindPk != null) {
+                    globalTrackChart.setSpotifyItemKind(session.get(SpotifyItemKind.class, spotifyItemKindPk));
+                }
+                globalTrackChart.setMonthly(true);
+                session.save(globalTrackChart);
+            }
+
+            for (Object[] record : getGlobalArtistChart(session)) {
+                GlobalArtistChart globalArtistChart = new GlobalArtistChart();
+                globalArtistChart.setArtist(session.get(Artist.class, ((BigInteger) record[0]).longValue()));
+                globalArtistChart.setCount(((BigInteger) record[1]).longValue());
+                globalArtistChart.setMonthly(false);
+                session.save(globalArtistChart);
+            }
+
+            for (Object[] record : getGlobalArtistMonthlyChart(session)) {
+                GlobalArtistChart globalArtistChart = new GlobalArtistChart();
+                globalArtistChart.setArtist(session.get(Artist.class, ((BigInteger) record[0]).longValue()));
+                globalArtistChart.setCount(((BigInteger) record[1]).longValue());
+                globalArtistChart.setMonthly(true);
+                session.save(globalArtistChart);
+            }
+        });
+    }
+
+    public SelectQueryBuilder<PlaybackHistory> getGlobalTrackChartQuery() {
+        return queryBuilderFactory
+            .select(PlaybackHistory.class,
+                (from, cb) -> from.get("fkSource"),
+                (from, cb) -> from.get("trackId"),
+                (from, cb) -> cb.count(from.get("pk")),
+                (from, cb) -> from.get("fkSpotifyItemKind"))
+            .where((cb, root) -> cb.isNotNull(root.get("trackId")))
+            .groupBySeveral((from, cb) -> Lists.newArrayList(from.get("trackId"), from.get("fkSource"), from.get("fkSpotifyItemKind")))
+            .orderBy((from, cb) -> cb.desc(cb.count(from.get("pk"))));
+    }
+
+    public List<Object[]> getGlobalTrackChart(Session session) {
+        return getGlobalTrackChartQuery().build(session).setMaxResults(10).getResultList();
+    }
+
+    public SelectQueryBuilder<GlobalTrackChart> getPersistentGlobalTrackChartQuery() {
+        return queryBuilderFactory
+            .select(GlobalTrackChart.class,
+                (from, cb) -> from.get("fkSource"),
+                (from, cb) -> from.get("trackId"),
+                (from, cb) -> from.get("count"),
+                (from, cb) -> from.get("fkSpotifyItemKind"))
+            .where((cb, root) -> cb.not(root.get("isMonthly")))
+            .orderBy((from, cb) -> cb.desc(from.get("count")));
+    }
+
+    public List<Object[]> getPersistentGlobalTrackChart(Session session) {
+        return getPersistentGlobalTrackChartQuery().build(session).setMaxResults(10).getResultList();
+    }
+
+    public SelectQueryBuilder<PlaybackHistory> getGlobalTrackMonthlyChartQuery() {
+        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        return getGlobalTrackChartQuery().fork().where((cb, root) -> cb.greaterThan(root.get("timestamp"), startOfMonth));
+    }
+
+    public List<Object[]> getGlobalTrackMonthlyChart(Session session) {
+        return getGlobalTrackMonthlyChartQuery().build(session).setMaxResults(10).getResultList();
+    }
+
+    public SelectQueryBuilder<GlobalTrackChart> getPersistentGlobalTrackMonthlyChartQuery() {
+        return queryBuilderFactory
+            .select(GlobalTrackChart.class,
+                (from, cb) -> from.get("fkSource"),
+                (from, cb) -> from.get("trackId"),
+                (from, cb) -> from.get("count"),
+                (from, cb) -> from.get("fkSpotifyItemKind"))
+            .where((cb, root) -> cb.isTrue(root.get("isMonthly")))
+            .orderBy((from, cb) -> cb.desc(from.get("count")));
+    }
+
+    public List<Object[]> getPersistentGlobalTrackMonthlyChart(Session session) {
+        return getPersistentGlobalTrackMonthlyChartQuery().build(session).setMaxResults(10).getResultList();
+    }
+
+    public SelectQueryBuilder<PlaybackHistory> getGuildTrackChartQuery(Guild guild) {
+        return getGlobalTrackChartQuery().fork().where((cb, root) -> cb.equal(root.get("guildId"), guild.getId()));
+    }
+
+    public List<Object[]> getGuildTrackChart(Guild guild, Session session) {
+        return getGuildTrackChartQuery(guild).build(session).setMaxResults(10).getResultList();
+    }
+
+    public SelectQueryBuilder<PlaybackHistory> getGuildTrackMonthlyChartQuery(Guild guild) {
+        return getGlobalTrackMonthlyChartQuery().fork().where((cb, root) -> cb.equal(root.get("guildId"), guild.getId()));
+    }
+
+    public List<Object[]> getGuildTrackMonthlyChart(Guild guild, Session session) {
+        return getGuildTrackMonthlyChartQuery(guild).build(session).setMaxResults(10).getResultList();
+    }
+
+    public SelectQueryBuilder<PlaybackHistory> getUserTrackChartQuery(User user, Session session) {
+        return getGlobalTrackChartQuery().where((cb, root, subQueryFactory) -> root.get("pk").in(
+            subQueryFactory
+                .createUncorrelatedSubQuery(UserPlaybackHistory.class, "playbackHistoryPk")
+                .where((cb1, root1) -> cb1.equal(root1.get("userId"), user.getId()))
+                .build(session)
+        ));
+    }
+
+    public List<Object[]> getUserTrackChart(User user, Session session) {
+        return getUserTrackChartQuery(user, session).build(session).setMaxResults(10).getResultList();
+    }
+
+    public SelectQueryBuilder<PlaybackHistory> getUserTrackMonthlyChartQuery(User user, Session session) {
+        return getGlobalTrackMonthlyChartQuery().fork().where((cb, root, subQueryFactory) -> root.get("pk").in(
+            subQueryFactory
+                .createUncorrelatedSubQuery(UserPlaybackHistory.class, "playbackHistoryPk")
+                .where((cb1, root1) -> cb1.equal(root1.get("userId"), user.getId()))
+                .build(session)
+        ));
+    }
+
+    public List<Object[]> getUserTrackMonthlyChart(User user, Session session) {
+        return getUserTrackMonthlyChartQuery(user, session).build(session).setMaxResults(10).getResultList();
+    }
+
+    public Query<Object[]> getGlobalArtistChartQuery(Session session) {
+        return session.createSQLQuery("select artist_pk, count(*) as c " +
+            "from playback_history_artist group by artist_pk order by c desc limit 5");
+    }
+
+    public List<Object[]> getGlobalArtistChart(Session session) {
+        return getGlobalArtistChartQuery(session).getResultList();
+    }
+
+    public Query<Object[]> getPersistentGlobalArtistChartQuery(Session session) {
+        return session.createSQLQuery("select artist_pk, count as c " +
+            "from global_artist_chart where not is_monthly order by c desc limit 5");
+    }
+
+    public List<Object[]> getPersistentGlobalArtistChart(Session session) {
+        return getPersistentGlobalArtistChartQuery(session).getResultList();
+    }
+
+    public Query<Object[]> getGlobalArtistMonthlyChartQuery(Session session) {
+        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        Date dateAtStartOfMonth = Date.valueOf(startOfMonth.toLocalDate());
+        Query<Object[]> globalArtistMonthlyQuery = session.createSQLQuery("select artist_pk, count(*) as c " +
+            "from playback_history_artist as p " +
+            "where p.playback_history_pk in(select pk from playback_history where timestamp > ?) " +
+            "group by artist_pk order by c desc limit 5");
+        globalArtistMonthlyQuery.setParameter(1, dateAtStartOfMonth);
+        return globalArtistMonthlyQuery;
+    }
+
+    public List<Object[]> getGlobalArtistMonthlyChart(Session session) {
+        return getGlobalArtistMonthlyChartQuery(session).getResultList();
+    }
+
+    public Query<Object[]> getPersistentGlobalArtistMonthlyChartQuery(Session session) {
+        return session.createSQLQuery("select artist_pk, count as c " +
+            "from global_artist_chart " +
+            "where is_monthly " +
+            "order by c desc limit 5");
+    }
+
+    public List<Object[]> getPersistentGlobalArtistMonthlyChart(Session session) {
+        return getPersistentGlobalArtistMonthlyChartQuery(session).getResultList();
+    }
+
+    public Query<Object[]> getGuildArtistChartQuery(Guild guild, Session session) {
+        Query<Object[]> guildArtistQuery = session.createSQLQuery("select artist_pk, count(*) as c from " +
+            "playback_history_artist as p where p.playback_history_pk in(select pk from playback_history where guild_id = ?) " +
+            "group by artist_pk order by c desc limit 5");
+        guildArtistQuery.setParameter(1, guild.getId());
+        return guildArtistQuery;
+    }
+
+    public List<Object[]> getGuildArtistChart(Guild guild, Session session) {
+        return getGuildArtistChartQuery(guild, session).getResultList();
+    }
+
+    public Query<Object[]> getGuildArtistMonthlyChartQuery(Guild guild, Session session) {
+        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        Date dateAtStartOfMonth = Date.valueOf(startOfMonth.toLocalDate());
+        Query<Object[]> guildArtistMonthlyQuery = session.createSQLQuery("select artist_pk, count(*) as c " +
+            "from playback_history_artist where playback_history_pk in(select pk from playback_history " +
+            "where timestamp > ? and guild_id = ?) " +
+            "group by artist_pk order by c desc limit 5");
+        guildArtistMonthlyQuery.setParameter(1, dateAtStartOfMonth);
+        guildArtistMonthlyQuery.setParameter(2, guild.getId());
+        return guildArtistMonthlyQuery;
+    }
+
+    public List<Object[]> getGuildArtistMonthlyChart(Guild guild, Session session) {
+        return getGuildArtistMonthlyChartQuery(guild, session).getResultList();
+    }
+
+    public Query<Object[]> getUserArtistChartQuery(User user, Session session) {
+        Query<Object[]> userArtistQuery = session.createSQLQuery("select artist_pk, count(*) as c from " +
+            "playback_history_artist as p where p.playback_history_pk in(select pk from playback_history where pk IN(SELECT playback_history_pk FROM user_playback_history WHERE user_id = ?)) " +
+            "group by artist_pk order by c desc limit 5");
+        userArtistQuery.setParameter(1, user.getId());
+        return userArtistQuery;
+    }
+
+    public List<Object[]> getUserArtistChart(User user, Session session) {
+        return getUserArtistChartQuery(user, session).getResultList();
+    }
+
+    public Query<Object[]> getUserArtistMonthlyChartQuery(User user, Session session) {
+        LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        Date dateAtStartOfMonth = Date.valueOf(startOfMonth.toLocalDate());
+        Query<Object[]> userArtistMonthlyQuery = session.createSQLQuery("select artist_pk, count(*) as c " +
+            "from playback_history_artist where playback_history_pk in(select pk from playback_history " +
+            "where timestamp > ? and pk IN(SELECT playback_history_pk FROM user_playback_history WHERE user_id = ?)) " +
+            "group by artist_pk order by c desc limit 5");
+        userArtistMonthlyQuery.setParameter(1, dateAtStartOfMonth);
+        userArtistMonthlyQuery.setParameter(2, user.getId());
+        return userArtistMonthlyQuery;
+    }
+
+    public List<Object[]> getUserArtistMonthlyChart(User user, Session session) {
+        return getUserArtistMonthlyChartQuery(user, session).getResultList();
+    }
+
+}

--- a/src/main/java/net/robinfriedli/aiode/boot/tasks/RefreshPersistentGlobalChartsStartupTask.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/tasks/RefreshPersistentGlobalChartsStartupTask.java
@@ -1,0 +1,41 @@
+package net.robinfriedli.aiode.boot.tasks;
+
+import net.dv8tion.jda.api.JDA;
+import net.robinfriedli.aiode.Aiode;
+import net.robinfriedli.aiode.audio.ChartService;
+import net.robinfriedli.aiode.boot.StartupTask;
+import net.robinfriedli.aiode.entities.xml.StartupTaskContribution;
+import org.jetbrains.annotations.Nullable;
+
+public class RefreshPersistentGlobalChartsStartupTask implements StartupTask {
+
+    private final ChartService chartService;
+    private final StartupTaskContribution contribution;
+
+    public RefreshPersistentGlobalChartsStartupTask(ChartService chartService, StartupTaskContribution contribution) {
+        this.chartService = chartService;
+        this.contribution = contribution;
+    }
+
+    @Override
+    public void perform(@Nullable JDA shard) throws Exception {
+        Thread persistentChartUpdateThread = new Thread(() -> {
+            Aiode.LOGGER.info("Starting to refresh persistent global charts");
+            long millis = System.currentTimeMillis();
+            try {
+                chartService.refreshPersistentGlobalCharts();
+            } catch (Exception e) {
+                Aiode.LOGGER.error("Error occurred refreshing persistent global charts", e);
+            }
+            Aiode.LOGGER.info("Completed refreshing persistent global charts after {}ms", System.currentTimeMillis() - millis);
+        });
+        persistentChartUpdateThread.setName("refresh-persistent-global-charts-thread");
+        persistentChartUpdateThread.setDaemon(true);
+        persistentChartUpdateThread.start();
+    }
+
+    @Override
+    public StartupTaskContribution getContribution() {
+        return contribution;
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/cron/tasks/RefreshPersistentGlobalChartsTask.java
+++ b/src/main/java/net/robinfriedli/aiode/cron/tasks/RefreshPersistentGlobalChartsTask.java
@@ -1,0 +1,25 @@
+package net.robinfriedli.aiode.cron.tasks;
+
+import net.robinfriedli.aiode.Aiode;
+import net.robinfriedli.aiode.audio.ChartService;
+import net.robinfriedli.aiode.cron.AbstractCronTask;
+import net.robinfriedli.aiode.function.modes.HibernateTransactionMode;
+import net.robinfriedli.exec.Mode;
+import org.quartz.JobExecutionContext;
+
+public class RefreshPersistentGlobalChartsTask extends AbstractCronTask {
+
+    @Override
+    protected void run(JobExecutionContext jobExecutionContext) throws Exception {
+        ChartService chartService = Aiode.get().getChartService();
+        Aiode.LOGGER.info("Starting to refresh persistent global charts");
+        long millis = System.currentTimeMillis();
+        chartService.refreshPersistentGlobalCharts();
+        Aiode.LOGGER.info("Completed refreshing persistent global charts after {}ms", System.currentTimeMillis() - millis);
+    }
+
+    @Override
+    protected Mode getMode() {
+        return Mode.create().with(new HibernateTransactionMode());
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/entities/GlobalArtistChart.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/GlobalArtistChart.java
@@ -1,0 +1,65 @@
+package net.robinfriedli.aiode.entities;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "global_artist_chart")
+public class GlobalArtistChart implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pk")
+    private long pk;
+
+    @Column(name = "count", nullable = false)
+    private long count;
+
+    @ManyToOne
+    @JoinColumn(name = "artist_pk", referencedColumnName = "pk", nullable = false, foreignKey = @ForeignKey(name = "global_artist_chart_artist_pk_fkey"))
+    private Artist artist;
+
+    @Column(name = "is_monthly")
+    private boolean isMonthly = false;
+
+    public long getPk() {
+        return pk;
+    }
+
+    public void setPk(long pk) {
+        this.pk = pk;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public Artist getArtist() {
+        return artist;
+    }
+
+    public void setArtist(Artist source) {
+        this.artist = source;
+    }
+
+    public boolean isMonthly() {
+        return isMonthly;
+    }
+
+    public void setMonthly(boolean monthly) {
+        isMonthly = monthly;
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/entities/GlobalTrackChart.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/GlobalTrackChart.java
@@ -1,0 +1,109 @@
+package net.robinfriedli.aiode.entities;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "global_track_chart")
+public class GlobalTrackChart implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pk")
+    private long pk;
+
+    @Column(name = "track_id", nullable = false)
+    private String trackId;
+
+    @Column(name = "count", nullable = false)
+    private long count;
+
+    @ManyToOne
+    @JoinColumn(name = "fk_source", referencedColumnName = "pk", nullable = false, foreignKey = @ForeignKey(name = "global_track_chart_fk_source_fkey"))
+    private PlaybackHistorySource source;
+
+    @ManyToOne
+    @JoinColumn(name = "fk_spotify_item_kind", referencedColumnName = "pk", foreignKey = @ForeignKey(name = "global_track_chart_fk_spotify_item_kind_fkey"))
+    private SpotifyItemKind spotifyItemKind;
+
+    @Column(name = "is_monthly")
+    private boolean isMonthly = false;
+
+    @Column(name = "fk_source", insertable = false, updatable = false)
+    private long fkSource;
+    @Column(name = "fk_spotify_item_kind", insertable = false, updatable = false)
+    private long fkSpotifyItemKind;
+
+    public long getPk() {
+        return pk;
+    }
+
+    public void setPk(long pk) {
+        this.pk = pk;
+    }
+
+    public String getTrackId() {
+        return trackId;
+    }
+
+    public void setTrackId(String trackId) {
+        this.trackId = trackId;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public PlaybackHistorySource getSource() {
+        return source;
+    }
+
+    public void setSource(PlaybackHistorySource source) {
+        this.source = source;
+    }
+
+    public SpotifyItemKind getSpotifyItemKind() {
+        return spotifyItemKind;
+    }
+
+    public void setSpotifyItemKind(SpotifyItemKind spotifyItemKind) {
+        this.spotifyItemKind = spotifyItemKind;
+    }
+
+    public boolean isMonthly() {
+        return isMonthly;
+    }
+
+    public void setMonthly(boolean monthly) {
+        isMonthly = monthly;
+    }
+
+    public long getFkSource() {
+        return fkSource;
+    }
+
+    public void setFkSource(long fkSource) {
+        this.fkSource = fkSource;
+    }
+
+    public long getFkSpotifyItemKind() {
+        return fkSpotifyItemKind;
+    }
+
+    public void setFkSpotifyItemKind(long fkSpotifyItemKind) {
+        this.fkSpotifyItemKind = fkSpotifyItemKind;
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/entities/UserPlaybackHistory.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/UserPlaybackHistory.java
@@ -35,6 +35,8 @@ public class UserPlaybackHistory implements Serializable {
     @ManyToOne
     @JoinColumn(name = "playback_history_pk", referencedColumnName = "pk", foreignKey = @ForeignKey(name = "fk_playback_history"))
     private PlaybackHistory playbackHistory;
+    @Column(name = "playback_history_pk", insertable = false, updatable = false)
+    private long playbackHistoryPk;
 
     public UserPlaybackHistory() {
     }
@@ -72,5 +74,13 @@ public class UserPlaybackHistory implements Serializable {
 
     public void setPlaybackHistory(PlaybackHistory playbackHistory) {
         this.playbackHistory = playbackHistory;
+    }
+
+    public long getPlaybackHistoryPk() {
+        return playbackHistoryPk;
+    }
+
+    public void setPlaybackHistoryPk(long playbackHistoryPk) {
+        this.playbackHistoryPk = playbackHistoryPk;
     }
 }

--- a/src/main/resources/liquibase/dbchangelog.xml
+++ b/src/main/resources/liquibase/dbchangelog.xml
@@ -972,4 +972,45 @@ See application.properties -> spring.liquibase.contexts
       <column name="playlist_pk"/>
     </createIndex>
   </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688838093355-1">
+    <createTable tableName="global_artist_chart">
+      <column autoIncrement="true" name="pk" type="BIGINT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="global_artist_chartPK"/>
+      </column>
+      <column name="count" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="is_monthly" type="BOOLEAN"/>
+      <column name="artist_pk" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688838093355-2">
+    <createTable tableName="global_track_chart">
+      <column autoIncrement="true" name="pk" type="BIGINT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="global_track_chartPK"/>
+      </column>
+      <column name="count" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="is_monthly" type="BOOLEAN"/>
+      <column name="track_id" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="fk_source" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="fk_spotify_item_kind" type="BIGINT"/>
+    </createTable>
+  </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688838093355-3">
+    <addForeignKeyConstraint baseColumnNames="artist_pk" baseTableName="global_artist_chart" constraintName="global_artist_chart_artist_pk_fkey" deferrable="false" initiallyDeferred="false" referencedColumnNames="pk" referencedTableName="artist" validate="true"/>
+  </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688838093355-4">
+    <addForeignKeyConstraint baseColumnNames="fk_source" baseTableName="global_track_chart" constraintName="global_track_chart_fk_source_fkey" deferrable="false" initiallyDeferred="false" referencedColumnNames="pk" referencedTableName="playback_history_source" validate="true"/>
+  </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688838093355-5">
+    <addForeignKeyConstraint baseColumnNames="fk_spotify_item_kind" baseTableName="global_track_chart" constraintName="global_track_chart_fk_spotify_item_kind_fkey" deferrable="false" initiallyDeferred="false" referencedColumnNames="pk" referencedTableName="spotify_item_kind" validate="true"/>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/xml-contributions/commands.xml
+++ b/src/main/resources/xml-contributions/commands.xml
@@ -438,7 +438,19 @@
            implementation="net.robinfriedli.aiode.command.commands.general.ChartsCommand"
            requiresInput="false"
            category="GENERAL"
-           description="Shows the most popular tracks and artists for this guild and globally"/>
+           description="Shows the most popular tracks and artists globally, for this guild or for this user">
+    <argument identifier="global" description="Show the global charts"/>
+    <argument identifier="guild" description="Show the charts for this guild">
+      <excludes argument="global"/>
+    </argument>
+    <argument identifier="user" description="Show the charts for this user">
+      <excludes argument="global"/>
+      <excludes argument="guild"/>
+    </argument>
+    <example title="Get global charts">%1$scharts</example>
+    <example title="Get current guild charts">%1$scharts %2$sguild</example>
+    <example title="Get current user charts">%1$scharts %2$suser</example>
+  </command>
   <command identifier="abort"
            implementation="net.robinfriedli.aiode.command.commands.general.AbortCommand"
            requiresInput="false"

--- a/src/main/resources/xml-contributions/cronJobs.xml
+++ b/src/main/resources/xml-contributions/cronJobs.xml
@@ -5,4 +5,5 @@
   <cronJob id="clearAbandonedGuildContexts" cron="0 */3 * * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.ClearAbandonedGuildContextsTask"/>
   <cronJob id="deleteGrantedRolesForDeletedRoles" cron="0 0 */1 * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.DeleteGrantedRolesForDeletedRolesTask"/>
   <cronJob id="resetCurrentYouTubeQuota" cron="0 0 0 * * ? *" timeZone="PST" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.cron.tasks.ResetCurrentYouTubeQuotaTask"/>
+  <cronJob id="refreshPersistentGlobalCharts" cron="0 0 6 * * ? *" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.cron.tasks.RefreshPersistentGlobalChartsTask"/>
 </cronJobs>

--- a/src/main/resources/xml-contributions/startupTasks.xml
+++ b/src/main/resources/xml-contributions/startupTasks.xml
@@ -9,4 +9,5 @@
   <startupTask runForEachShard="false" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.boot.tasks.ResetOutdatedYouTubeQuotaTask"/>
   <startupTask runForEachShard="false" implementation="net.robinfriedli.aiode.boot.tasks.InitialiseCommandContributionsTask"/>
   <startupTask runForEachShard="true" implementation="net.robinfriedli.aiode.boot.tasks.UpsertSlashCommandsTask"/>
+  <startupTask runForEachShard="false" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.boot.tasks.RefreshPersistentGlobalChartsStartupTask"/>
 </startupTasks>


### PR DESCRIPTION
- refresh global charts once a day and adjust ChartsCommand to return persistent stats instead of calculating them on demand
- add user charts
- split global, guild and user charts into separate arguments and show more items