### PR TITLE
improve AnalyticsCommand performance

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/command/commands/general/AnalyticsCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/general/AnalyticsCommand.java
@@ -2,6 +2,7 @@ package net.robinfriedli.aiode.command.commands.general;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.math.BigInteger;
 import java.util.List;
 
 import com.google.common.base.Strings;
@@ -16,12 +17,6 @@ import net.robinfriedli.aiode.command.AbstractCommand;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.CommandManager;
 import net.robinfriedli.aiode.discord.GuildManager;
-import net.robinfriedli.aiode.entities.CommandHistory;
-import net.robinfriedli.aiode.entities.PlaybackHistory;
-import net.robinfriedli.aiode.entities.Playlist;
-import net.robinfriedli.aiode.entities.Song;
-import net.robinfriedli.aiode.entities.UrlTrack;
-import net.robinfriedli.aiode.entities.Video;
 import net.robinfriedli.aiode.entities.xml.CommandContribution;
 import org.hibernate.Session;
 
@@ -44,12 +39,12 @@ public class AnalyticsCommand extends AbstractCommand {
 
         int guildCount = guilds.size();
         long playingCount = guilds.stream().map(audioManager::getPlaybackForGuild).filter(AudioPlayback::isPlaying).count();
-        long commandCount = session.createQuery("select count(*) from " + CommandHistory.class.getName(), Long.class).uniqueResult();
-        long playlistCount = session.createQuery("select count(*) from " + Playlist.class.getName(), Long.class).uniqueResult();
-        long trackCount = session.createQuery("select count(*) from " + Song.class.getName(), Long.class).uniqueResult()
-            + session.createQuery("select count(*) from " + Video.class.getName(), Long.class).uniqueResult()
-            + session.createQuery("select count(*) from " + UrlTrack.class.getName(), Long.class).uniqueResult();
-        long playedCount = session.createQuery("select count(*) from " + PlaybackHistory.class.getName(), Long.class).uniqueResult();
+        long commandCount = ((BigInteger) session.createSQLQuery("SELECT cast(reltuples AS bigint) FROM pg_class where relname = 'command_history'").uniqueResult()).longValue();
+        long playlistCount = ((BigInteger) session.createSQLQuery("SELECT cast(reltuples AS bigint) FROM pg_class where relname = 'playlist'").uniqueResult()).longValue();
+        long trackCount = ((BigInteger) session.createSQLQuery("SELECT cast(reltuples AS bigint) FROM pg_class where relname = 'song'").uniqueResult()).longValue()
+            + ((BigInteger) session.createSQLQuery("SELECT cast(reltuples AS bigint) FROM pg_class where relname = 'video'").uniqueResult()).longValue()
+            + ((BigInteger) session.createSQLQuery("SELECT cast(reltuples AS bigint) FROM pg_class where relname = 'url_track'").uniqueResult()).longValue();
+        long playedCount = ((BigInteger) session.createSQLQuery("SELECT cast(reltuples AS bigint) FROM pg_class where relname = 'playback_history'").uniqueResult()).longValue();
         // convert to MB by right shifting by 20 bytes (same as dividing by 2^20)
         long maxMemory = runtime.maxMemory() >> 20;
         long allocatedMemory = runtime.totalMemory() >> 20;

--- a/src/main/java/net/robinfriedli/aiode/entities/CommandHistory.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/CommandHistory.java
@@ -8,10 +8,15 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Table;
 
 @Entity
-@Table(name = "command_history")
+@Table(name = "command_history", indexes = {
+    @Index(name = "command_history_guild_id_idx", columnList = "guild_id"),
+    @Index(name = "command_history_user_id_idx", columnList = "user_id"),
+    @Index(name = "command_history_start_millis_idx", columnList = "start_millis")
+})
 public class CommandHistory implements Serializable {
 
     @Id

--- a/src/main/java/net/robinfriedli/aiode/entities/GlobalTrackChart.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/GlobalTrackChart.java
@@ -38,7 +38,7 @@ public class GlobalTrackChart implements Serializable {
     @Column(name = "is_monthly")
     private boolean isMonthly = false;
 
-    @Column(name = "fk_source", insertable = false, updatable = false)
+    @Column(name = "fk_source", nullable = false, insertable = false, updatable = false)
     private long fkSource;
     @Column(name = "fk_spotify_item_kind", insertable = false, updatable = false)
     private long fkSpotifyItemKind;

--- a/src/main/java/net/robinfriedli/aiode/entities/PlaybackHistory.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/PlaybackHistory.java
@@ -32,7 +32,8 @@ import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
 @Entity
 @Table(name = "playback_history", indexes = {
     @Index(name = "playback_history_guild_id_idx", columnList = "guild_id"),
-    @Index(name = "playback_history_track_id_idx", columnList = "track_id")
+    @Index(name = "playback_history_track_id_idx", columnList = "track_id"),
+    @Index(name = "playback_history_timestamp_idx", columnList = "timestamp"),
 })
 public class PlaybackHistory implements Serializable {
 

--- a/src/main/resources/liquibase/dbchangelog.xml
+++ b/src/main/resources/liquibase/dbchangelog.xml
@@ -1013,4 +1013,24 @@ See application.properties -> spring.liquibase.contexts
   <changeSet author="robinfriedli (generated)" id="1688838093355-5">
     <addForeignKeyConstraint baseColumnNames="fk_spotify_item_kind" baseTableName="global_track_chart" constraintName="global_track_chart_fk_spotify_item_kind_fkey" deferrable="false" initiallyDeferred="false" referencedColumnNames="pk" referencedTableName="spotify_item_kind" validate="true"/>
   </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688850825715-1">
+    <createIndex indexName="command_history_guild_id_idx" tableName="command_history">
+      <column name="guild_id"/>
+    </createIndex>
+  </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688850825715-2">
+    <createIndex indexName="command_history_start_millis_idx" tableName="command_history">
+      <column name="start_millis"/>
+    </createIndex>
+  </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688850825715-3">
+    <createIndex indexName="command_history_user_id_idx" tableName="command_history">
+      <column name="user_id"/>
+    </createIndex>
+  </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1688852021628-1">
+    <createIndex indexName="playback_history_timestamp_idx" tableName="playback_history">
+      <column name="timestamp"/>
+    </createIndex>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
- use estimated counts for entities by selecting the reltuples column instead of getting an accurate count
- add additional indexes to PlaybackHistory and CommandHistory to find active guilds faster