### PR TITLE
expand AudioQueue management

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/command/commands/playback/PlayCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/playback/PlayCommand.java
@@ -115,7 +115,7 @@ public class PlayCommand extends AbstractQueueLoadingCommand {
             audioPlayer.stopTrack();
         }
 
-        queue.addContainers(playableContainers, playableFactory, true);
+        queue.addContainers(playableContainers, playableFactory, true, null);
 
         audioManager.startPlayback(guild, getContext().getAudioChannel());
     }

--- a/src/main/java/net/robinfriedli/aiode/command/commands/playback/RewindCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/playback/RewindCommand.java
@@ -30,7 +30,7 @@ public class RewindCommand extends AbstractCommand {
             throw new InvalidCommandException("No previous item in queue");
         }
 
-        int queueSize = queue.getTracks().size();
+        int queueSize = queue.getSize();
         if (getCommandInput().isBlank()) {
             queue.reverse();
         } else {

--- a/src/main/java/net/robinfriedli/aiode/command/commands/playback/SkipCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/playback/SkipCommand.java
@@ -45,7 +45,7 @@ public class SkipCommand extends AbstractCommand {
             }
 
             int newIndex;
-            int queueSize = queue.getTracks().size();
+            int queueSize = queue.getSize();
             boolean overflow = queue.getPosition() + offset >= queueSize;
             if (!playback.isRepeatAll() && overflow) {
                 newIndex = queueSize - 1;

--- a/src/main/java/net/robinfriedli/aiode/servers/QueueViewHandler.java
+++ b/src/main/java/net/robinfriedli/aiode/servers/QueueViewHandler.java
@@ -51,7 +51,7 @@ public class QueueViewHandler implements HttpHandler {
                         try {
                             int position = queue.getPosition();
                             List<Playable> previous = queue.listPrevLocked(position);
-                            List<Playable> next = queue.listNextLocked(queue.getTracks().size() - position);
+                            List<Playable> next = queue.listNextLocked(queue.getSize() - position);
 
                             StringBuilder listBuilder = new StringBuilder();
                             if (!previous.isEmpty()) {

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/PlayableContainerQueueFragment.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/PlayableContainerQueueFragment.kt
@@ -1,11 +1,8 @@
 package net.robinfriedli.aiode.audio.queue
 
-import com.google.common.collect.Sets
+import com.google.common.collect.Lists
 import net.robinfriedli.aiode.audio.Playable
 import net.robinfriedli.aiode.audio.playables.PlayableContainer
-import net.robinfriedli.aiode.audio.playables.containers.SinglePlayableContainer
-import java.util.*
-import java.util.stream.Collectors
 import java.util.stream.IntStream
 
 class PlayableContainerQueueFragment(
@@ -14,69 +11,7 @@ class PlayableContainerQueueFragment(
     private val playableContainer: PlayableContainer<*>
 ) : QueueFragment {
 
-    private var currentIndex: Int = -1
-    private var randomOrder: MutableList<Int>? = null
-
-    private var fractures: MutableSet<Int> = Sets.newHashSet()
-    private var altFractures: MutableSet<Int>? = null
-
-    override fun currentIndex(): Int {
-        return currentIndex
-    }
-
-    override fun next(): Playable {
-        return if (randomOrder != null) {
-            playables[randomOrder!![++currentIndex]]
-        } else {
-            playables[++currentIndex]
-        }
-    }
-
-    override fun current(): Playable {
-        return if (randomOrder != null) {
-            playables[randomOrder!![currentIndex]]
-        } else {
-            playables[currentIndex]
-        }
-    }
-
-    override fun hasNext(fractureIdx: Int): Boolean {
-        return if (currentIndex < size() - 1) {
-            val (_, end) = getFractureRange(fractureIdx)
-            currentIndex < end - 1
-        } else {
-            false
-        }
-    }
-
-    override fun hasPrevious(fractureIdx: Int): Boolean {
-        return if (currentIndex > 0) {
-            val (start, _) = getFractureRange(fractureIdx)
-            currentIndex > start
-        } else {
-            false
-        }
-    }
-
-    override fun previous(): Playable {
-        return if (randomOrder != null) {
-            playables[randomOrder!![--currentIndex]]
-        } else {
-            playables[--currentIndex]
-        }
-    }
-
-    override fun peekNext(): Playable? {
-        return if (currentIndex < size() - 1) {
-            if (randomOrder != null) {
-                playables[randomOrder!![currentIndex + 1]]
-            } else {
-                playables[currentIndex + 1]
-            }
-        } else {
-            null
-        }
-    }
+    private var fractures: MutableList<Pair<Int, Int>> = Lists.newArrayList(Pair(0, size()))
 
     override fun size(): Int {
         return playables.size
@@ -91,160 +26,53 @@ class PlayableContainerQueueFragment(
     }
 
     override fun addFracture(idx: Int): Int {
-        fractures.add(idx)
-        return fractures.size
+        if (idx <= 0 || idx >= size()) {
+            throw IndexOutOfBoundsException("Cannot create fracture at index $idx")
+        }
+
+        val (parentFractureIdx, parentFracture) = IntStream
+            .range(0, fractures.size)
+            .mapToObj { i -> Pair(i, fractures[i]) }
+            .sorted(Comparator.comparing { (_, fracture) -> fracture.first })
+            .filter { (_, fracture) -> fracture.first <= idx && fracture.second > idx }
+            .findFirst()
+            .orElseThrow { IllegalStateException("Could not find suitable parent fracture for index $idx") }
+
+        if (parentFracture.first == idx) {
+            throw IllegalStateException("Fragment is already fractured at $idx")
+        }
+
+        fractures[parentFractureIdx] = Pair(parentFracture.first, idx)
+        fractures.add(Pair(idx, parentFracture.second))
+        return fractures.size - 1
     }
 
-    override fun getOrderedFractures(): List<Int> {
-        return fractures.stream().sorted().toList()
+    override fun addFracture(fractureIdx: Int, idx: Int): Int {
+        return addFracture(fractures[fractureIdx].first + idx)
     }
 
     override fun getPlayables(): List<Playable> {
         return playables
     }
 
-    override fun getPlayablesInCurrentOrder(): List<Playable> {
-        return if (randomOrder != null) {
-            randomOrder!!
-                .stream()
-                .map { idx -> playables[idx] }
-                .toList()
-        } else {
-            getPlayables()
-        }
-    }
-
     override fun getPlayableInFracture(fractureIdx: Int, idx: Int): Playable {
-        val (start, end) = getFractureRange(fractureIdx)
+        val (start, end) = fractures[fractureIdx]
         val absoluteIdx = start + idx
 
         if (absoluteIdx >= end) {
             throw IndexOutOfBoundsException("Index $idx out of bounds for fracture of size ${end - start}")
         }
 
-        return getPlayablesInCurrentOrder()[absoluteIdx]
+        return playables[absoluteIdx]
     }
 
     override fun getPlayablesInFracture(fractureIdx: Int): List<Playable> {
-        val (start, end) = getFractureRange(fractureIdx)
-        return getPlayablesInCurrentOrder().subList(start, end)
-    }
-
-    override fun getNextPlayablesInFracture(fractureIdx: Int, limit: Int): List<Playable> {
-        val (start, end) = getFractureRange(fractureIdx)
-        val nextStart = currentIndex + 1
-
-        return if (currentIndex in start until end) {
-            getPlayablesInCurrentOrder().subList(nextStart, (nextStart + limit).coerceAtMost(end))
-        } else {
-            getPlayablesInCurrentOrder().subList(start, (start + limit).coerceAtMost(end))
-        }
-    }
-
-    override fun getPreviousPlayablesInFracture(fractureIdx: Int, limit: Int): List<Playable> {
-        val (start, end) = getFractureRange(fractureIdx)
-        val prevEnd = currentIndex
-
-        return if (prevEnd in start until end) {
-            getPlayablesInCurrentOrder().subList((prevEnd - limit).coerceAtLeast(start), prevEnd)
-        } else {
-            getPlayablesInCurrentOrder().subList((end - limit).coerceAtLeast(start), end)
-        }
+        val (start, end) = fractures[fractureIdx]
+        return ArrayList(playables).subList(start, end)
     }
 
     override fun sizeOfFracture(fractureIdx: Int): Int {
-        val (start, end) = getFractureRange(fractureIdx)
+        val (start, end) = fractures[fractureIdx]
         return end - start
-    }
-
-    override fun currentIndexWithinFracture(fractureIdx: Int): Int {
-        val (start, end) = getFractureRange(fractureIdx)
-
-        return if (currentIndex in start until end) {
-            currentIndex - start
-        } else {
-            -1
-        }
-    }
-
-    override fun setPosition(fractureIdx: Int, offset: Int) {
-        val (start, _) = getFractureRange(fractureIdx)
-        currentIndex = start + offset
-    }
-
-    override fun resetPositionToStart() {
-        currentIndex = -1
-    }
-
-    override fun resetPositionToEnd() {
-        currentIndex = size()
-    }
-
-    override fun enableShuffle(protectCurrent: Boolean): Int {
-        val size = size()
-        val range = IntStream.range(0, size).boxed().collect(Collectors.toList())
-        range.shuffle()
-        randomOrder = range
-
-        if (protectCurrent && currentIndex >= 0) {
-            // make sure the current track is at index 0 / at the start of randomOrder
-            if (randomOrder!![0] != currentIndex) {
-                val indexOfCurrent = randomOrder!!.indexOf(currentIndex)
-                val prev = randomOrder!!.set(0, currentIndex)
-                randomOrder!![indexOfCurrent] = prev
-            }
-
-            currentIndex = 0
-        }
-
-        val randomFractureCount = Random().nextInt(size)
-
-        val random = Random()
-        altFractures = fractures
-        fractures = Sets.newHashSet()
-        for (i in 0 until randomFractureCount) {
-            // values returned by the same generator are likely unique, occasional duplicate values are not a problem,
-            // just means fewer fractures than randomFractureCount
-            fractures.add((random.nextInt(size) + 1).coerceAtMost(size - 1))
-        }
-
-        return fractures.size
-    }
-
-    override fun disableShuffle() {
-        if (currentIndex >= 0 && randomOrder != null) {
-            currentIndex = randomOrder!![currentIndex]
-        }
-        randomOrder = null
-        if (altFractures != null) {
-            fractures = altFractures!!
-        }
-        altFractures = null
-    }
-
-    override fun reduceToCurrentPlayable(): SinglePlayableQueueFragment {
-        return if (randomOrder != null) {
-            SinglePlayableQueueFragment(queue, playables[randomOrder!![currentIndex]], SinglePlayableContainer(playables[randomOrder!![currentIndex]]))
-        } else {
-            SinglePlayableQueueFragment(queue, playables[currentIndex], SinglePlayableContainer(playables[currentIndex]))
-        }
-    }
-
-    private fun getFractureRange(fractureIdx: Int): Pair<Int, Int> {
-        val fractures = getOrderedFractures()
-        // there always is one fracture at idx 0
-        return if (fractureIdx == 0) {
-            if (fractures.isEmpty()) {
-                Pair(0, playables.size)
-            } else {
-                Pair(0, fractures[0])
-            }
-        } else if (fractureIdx > 0 && fractureIdx < fractures.size) {
-            Pair(fractures[fractureIdx - 1], fractures[fractureIdx])
-        } else if (fractureIdx > 0 && fractureIdx == fractures.size) {
-            Pair(fractures[fractureIdx - 1], playables.size)
-        } else {
-            throw IndexOutOfBoundsException("Index $fractureIdx out of bounds for fragment with ${fractures.size + 1} fractures")
-        }
     }
 }

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/QueueFragment.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/QueueFragment.kt
@@ -10,35 +10,6 @@ import net.robinfriedli.aiode.audio.playables.PlayableContainer
 interface QueueFragment {
 
     /**
-     * Get the index within this fragment of the current track, returns -1 if this fragment is not currently playing.
-     */
-    fun currentIndex(): Int
-
-    /**
-     * Get the next element to play from this fragment, throws if [hasNext] returns false.
-     */
-    fun next(): Playable
-
-    /**
-     * Require the current track or throw
-     */
-    fun current(): Playable
-
-    /**
-     * Return `true` if there is a next element in the given fracture of this fragment.
-     */
-    fun hasNext(fractureIdx: Int): Boolean
-
-    /**
-     * Return `true` if there is a previous element in the given fracture of this fragment.
-     */
-    fun hasPrevious(fractureIdx: Int): Boolean
-
-    fun previous(): Playable
-
-    fun peekNext(): Playable?
-
-    /**
      * Return the number of [Playable] instances in this fragment. The size should never be less than 1, if the last element
      * is removed from a fragment, the fragment gets removed from the queue entirely.
      */
@@ -67,17 +38,15 @@ interface QueueFragment {
      */
     fun addFracture(idx: Int): Int
 
-    fun getOrderedFractures(): List<Int>
+    /**
+     * Fracture the fragment at the given index, relative to the start of the given fracture.
+     */
+    fun addFracture(fractureIdx: Int, idx: Int): Int
 
     /**
      * @return all Playables in this fragment
      */
     fun getPlayables(): List<Playable>
-
-    /**
-     * @return all Playables in this fragment in the current queue order, i.e. the shuffled order if shuffle is enabled
-     */
-    fun getPlayablesInCurrentOrder(): List<Playable>
 
     /**
      * @return the Playable at the given index within the given fracture
@@ -89,48 +58,6 @@ interface QueueFragment {
      */
     fun getPlayablesInFracture(fractureIdx: Int): List<Playable>
 
-    /**
-     * Return maximum [limit] tracks from the provided fracture, if the current position lies within the given fracture
-     * this only returns tracks after the current track.
-     */
-    fun getNextPlayablesInFracture(fractureIdx: Int, limit: Int): List<Playable>
-
-    /**
-     * Return maximum [limit] tracks from the provided fracture, if the current position lies within the given fracture
-     * this only returns tracks before the current track.
-     */
-    fun getPreviousPlayablesInFracture(fractureIdx: Int, limit: Int): List<Playable>
-
     fun sizeOfFracture(fractureIdx: Int): Int
-
-    /**
-     * @return the index relative to the start of the given fracture, -1 if the given fracture is not currently playing
-     */
-    fun currentIndexWithinFracture(fractureIdx: Int): Int
-
-    /**
-     * Set the position to the track within the given fracture and offset within that fracture.
-     */
-    fun setPosition(fractureIdx: Int, offset: Int)
-
-    fun resetPositionToStart()
-    fun resetPositionToEnd()
-
-    /**
-     * Shuffles this fragment. If this fragment contains several playables, it may create random fractures to enable other
-     * fragments to be placed at indices within this fragment, otherwise all tracks of the same fragment would remain
-     * grouped together when enabling shuffle.
-     *
-     * @param protectCurrent whether to make sure to keep the current item at the same index when currently playing
-     * @return the number of random fractures created
-     */
-    fun enableShuffle(protectCurrent: Boolean): Int
-
-    fun disableShuffle()
-
-    /**
-     * Return a queue fragment representing the current element. May throw if this fragment isn't the current fragment.
-     */
-    fun reduceToCurrentPlayable(): SinglePlayableQueueFragment
 
 }

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/SinglePlayableQueueFragment.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/SinglePlayableQueueFragment.kt
@@ -11,42 +11,6 @@ class SinglePlayableQueueFragment(
     private val playableContainer: AbstractSinglePlayableContainer<*>
 ) : QueueFragment {
 
-    override fun currentIndex(): Int {
-        return 0
-    }
-
-    override fun next(): Playable {
-        return playable
-    }
-
-    override fun current(): Playable {
-        return playable
-    }
-
-    override fun hasNext(fractureIdx: Int): Boolean {
-        return if (fractureIdx > 0) {
-            throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
-        } else {
-            false
-        }
-    }
-
-    override fun hasPrevious(fractureIdx: Int): Boolean {
-        return if (fractureIdx > 0) {
-            throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
-        } else {
-            false
-        }
-    }
-
-    override fun previous(): Playable {
-        return playable
-    }
-
-    override fun peekNext(): Playable {
-        return playable
-    }
-
     override fun size(): Int {
         return 1
     }
@@ -63,16 +27,12 @@ class SinglePlayableQueueFragment(
         throw UnsupportedOperationException("Cannot fracture ${javaClass.simpleName}")
     }
 
-    override fun getOrderedFractures(): List<Int> {
-        return Collections.emptyList()
+    override fun addFracture(fractureIdx: Int, idx: Int): Int {
+        throw UnsupportedOperationException("Cannot fracture ${javaClass.simpleName}")
     }
 
     override fun getPlayables(): List<Playable> {
         return Collections.singletonList(playable)
-    }
-
-    override fun getPlayablesInCurrentOrder(): List<Playable> {
-        return getPlayables()
     }
 
     override fun getPlayableInFracture(fractureIdx: Int, idx: Int): Playable {
@@ -93,60 +53,11 @@ class SinglePlayableQueueFragment(
         }
     }
 
-    override fun getNextPlayablesInFracture(fractureIdx: Int, limit: Int): List<Playable> {
-        return if (fractureIdx > 0) {
-            throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
-        } else {
-            Collections.emptyList()
-        }
-    }
-
-    override fun getPreviousPlayablesInFracture(fractureIdx: Int, limit: Int): List<Playable> {
-        return if (fractureIdx > 0) {
-            throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
-        } else {
-            Collections.emptyList()
-        }
-    }
-
     override fun sizeOfFracture(fractureIdx: Int): Int {
         return if (fractureIdx > 0) {
             throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
         } else {
             1
         }
-    }
-
-    override fun currentIndexWithinFracture(fractureIdx: Int): Int {
-        return if (fractureIdx > 0) {
-            throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
-        } else {
-            currentIndex()
-        }
-    }
-
-    override fun setPosition(fractureIdx: Int, offset: Int) {
-        if (fractureIdx > 0) {
-            throw IndexOutOfBoundsException("Fracture index $fractureIdx out of bounds for ${javaClass.simpleName}")
-        } else if (offset > 0) {
-            throw IndexOutOfBoundsException("Offset $offset out of bounds for ${javaClass.simpleName}")
-        }
-    }
-
-    override fun resetPositionToStart() {
-    }
-
-    override fun resetPositionToEnd() {
-    }
-
-    override fun enableShuffle(protectCurrent: Boolean): Int {
-        return 0
-    }
-
-    override fun disableShuffle() {
-    }
-
-    override fun reduceToCurrentPlayable(): SinglePlayableQueueFragment {
-        return this
     }
 }

--- a/src/main/resources/xml-contributions/commands.xml
+++ b/src/main/resources/xml-contributions/commands.xml
@@ -91,6 +91,35 @@
     <example title="Add tracks from a Spotify playlist in the current user's library to the queue">%1$squeue %2$slist %2$sspotify %2$sown favs</example>
     <example title="Add a YouTube playlist to the queue">%1$squeue %2$syoutube %2$slist memes</example>
     <example title="Add a YouTube playlist to the queue, showing a selection of 5 results">%1$squeue %2$syoutube %2$slist %2$slimit=5 memes</example>
+    <example title="Remove the next 3 tracks from the queue">%1$squeue %2$sremove 1 - 3</example>
+    <example title="Insert track Numb after the current track">%1$squeue %2$sinsert Numb</example>
+    <example title="Insert album Meteora after the 4th to next in the queue">%1$squeue %2$sinsert %2$sat=4 %2$salbum Meteora</example>
+    <argument identifier="remove" requiresInput="true" description="Remove the provided index range (relative to the current position) from the queue. Indexing starts at 1 (so 1 is the next track in the queue) and the range includes the end index (so 1-3 removes the next 3 tracks in the queue).">
+      <excludes argument="album"/>
+      <excludes argument="episode"/>
+      <excludes argument="list"/>
+      <excludes argument="local"/>
+      <excludes argument="market"/>
+      <excludes argument="own"/>
+      <excludes argument="podcast"/>
+      <excludes argument="preview"/>
+      <excludes argument="select"/>
+      <excludes argument="soundcloud"/>
+      <excludes argument="spotify"/>
+      <excludes argument="spotify"/>
+      <excludes argument="youtube"/>
+    </argument>
+    <argument identifier="insert" requiresInput="true" description="Insert items into the queue at a given position. By default or if the 'next' argument is set the items are inserted after the current track, the 'at' argument may be used to insert items at the specified index relative to the current position.">
+      <excludes argument="remove"/>
+    </argument>
+    <argument identifier="next" description="Inserts items after the current position in the queue when used in combination with the 'insert' argument.">
+      <requires argument="insert"/>
+    </argument>
+    <argument identifier="at" valueType="java.lang.Integer" requiresValue="true" description="Inserts items at the given index relative to the current position in the queue when used in combination with the 'insert' argument. Indexing starts at 1, so index 2 inserts the items after the next track in the queue and index 1 inserts the items after the current track (though in that case the 'next' argument should be used instead).">
+      <excludes argument="next"/>
+      <requires argument="insert"/>
+      <rule errorMessage="Index must be 1 or greater">value > 0</rule>
+    </argument>
   </command>
   <command identifier="remove"
            implementation="net.robinfriedli.aiode.command.commands.playlistmanagement.RemoveCommand"


### PR DESCRIPTION
- implement methods to remove items at given index ranges by splitting the range into separate QueueNodes and removing them from the QueueNodeList
- overhaul shuffle implementation
  - add shuffledOrder list that contains all indexes for all items in the queue in randomised order and use the index at the current position within that list to get the current track (analogous to the previous implementation), instead of having a separate QueueNodeList with a randomised order
  - this makes removing items from the queue (and disabling shuffle) far easier and more efficient
- add flattenedQueue that stores all tracks in a random access list and use that list when retrieving the current track instead of iterating through the linked QueueNodeList
- expand QueueCommand with arguments to insert and remove tracks