### PR TITLE
expand widgets

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/audio/youtube/HollowYouTubeVideo.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/youtube/HollowYouTubeVideo.java
@@ -157,7 +157,7 @@ public class HollowYouTubeVideo extends AbstractSoftCachedPlayable implements Yo
     private <E> E getCompleted(CompletableFuture<E> future) throws UnavailableResourceException {
         try {
             try {
-                return future.get(2, TimeUnit.SECONDS);
+                return future.get(100, TimeUnit.MILLISECONDS);
             } catch (TimeoutException e) {
                 fetch();
 

--- a/src/main/java/net/robinfriedli/aiode/boot/configurations/JxpComponent.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/configurations/JxpComponent.java
@@ -36,6 +36,7 @@ public class JxpComponent {
             .mapClass("version", Version.class)
             .mapClass("feature", Version.Feature.class)
             .mapClass("groovyVariableProvider", GroovyVariableProviderContribution.class)
+            .mapClass("action-row", WidgetContribution.WidgetActionRow.class)
             .build();
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/CommandContext.java
+++ b/src/main/java/net/robinfriedli/aiode/command/CommandContext.java
@@ -11,8 +11,8 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.robinfriedli.aiode.concurrent.CommandExecutionTask;
 import net.robinfriedli.aiode.concurrent.ExecutionContext;
@@ -86,7 +86,7 @@ public class CommandContext extends ExecutionContext {
     }
 
     public CommandContext(
-        MessageReactionAddEvent event,
+        ButtonInteractionEvent event,
         GuildContext guildContext,
         String message,
         SessionFactory sessionFactory,
@@ -104,7 +104,7 @@ public class CommandContext extends ExecutionContext {
             commandBody,
             event.getChannel(),
             false,
-            null
+            event.getHook()
         );
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/commands/general/HelpCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/general/HelpCommand.java
@@ -18,7 +18,9 @@ import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.CommandManager;
 import net.robinfriedli.aiode.command.argument.ArgumentController;
 import net.robinfriedli.aiode.command.argument.CommandArgument;
+import net.robinfriedli.aiode.command.widget.widgets.PaginatedMessageEmbedWidget;
 import net.robinfriedli.aiode.discord.property.properties.ArgumentPrefixProperty;
+import net.robinfriedli.aiode.discord.property.properties.ColorSchemeProperty;
 import net.robinfriedli.aiode.discord.property.properties.PrefixProperty;
 import net.robinfriedli.aiode.entities.AccessConfiguration;
 import net.robinfriedli.aiode.entities.GuildSpecification;
@@ -112,7 +114,15 @@ public class HelpCommand extends AbstractCommand {
                 }
             }
 
-            sendMessage(embedBuilder);
+            embedBuilder.setColor(ColorSchemeProperty.getColor());
+            PaginatedMessageEmbedWidget paginatedMessageEmbedWidget = new PaginatedMessageEmbedWidget(
+                getContext().getGuildContext().getWidgetRegistry(),
+                guild,
+                getContext().getChannel(),
+                embedBuilder.build()
+            );
+
+            paginatedMessageEmbedWidget.initialise();
         }, () -> {
             throw new InvalidCommandException(String.format("No command found for '%s'", getCommandInput()));
         });

--- a/src/main/java/net/robinfriedli/aiode/command/widget/AbstractPaginationAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/AbstractPaginationAction.java
@@ -1,11 +1,11 @@
 package net.robinfriedli.aiode.command.widget;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.command.CommandContext;
 
 public abstract class AbstractPaginationAction extends AbstractWidgetAction {
 
-    public AbstractPaginationAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public AbstractPaginationAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/FirstPageAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/FirstPageAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationAction;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationWidget;
@@ -9,7 +9,7 @@ import net.robinfriedli.aiode.command.widget.WidgetManager;
 
 public class FirstPageAction extends AbstractPaginationAction {
 
-    public FirstPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public FirstPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/LastPageAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/LastPageAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationAction;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationWidget;
@@ -9,7 +9,7 @@ import net.robinfriedli.aiode.command.widget.WidgetManager;
 
 public class LastPageAction extends AbstractPaginationAction {
 
-    public LastPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public LastPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/NextPageAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/NextPageAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationAction;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationWidget;
@@ -9,7 +9,7 @@ import net.robinfriedli.aiode.command.widget.WidgetManager;
 
 public class NextPageAction extends AbstractPaginationAction {
 
-    public NextPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public NextPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/PlayPauseAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/PlayPauseAction.java
@@ -2,7 +2,7 @@ package net.robinfriedli.aiode.command.widget.actions;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.Aiode;
 import net.robinfriedli.aiode.audio.AudioManager;
 import net.robinfriedli.aiode.audio.AudioPlayback;
@@ -20,7 +20,7 @@ public class PlayPauseAction extends AbstractWidgetAction {
     private final AudioPlayback audioPlayback;
     private final AudioManager audioManager;
 
-    public PlayPauseAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public PlayPauseAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
         audioPlayback = getContext().getGuildContext().getPlayback();
         audioManager = Aiode.get().getAudioManager();

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/PrevPageAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/PrevPageAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationAction;
 import net.robinfriedli.aiode.command.widget.AbstractPaginationWidget;
@@ -9,7 +9,7 @@ import net.robinfriedli.aiode.command.widget.WidgetManager;
 
 public class PrevPageAction extends AbstractPaginationAction {
 
-    public PrevPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public PrevPageAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/RepeatAllAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/RepeatAllAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.audio.AudioPlayback;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractWidget;
@@ -11,7 +11,7 @@ public class RepeatAllAction extends AbstractWidgetAction {
 
     private final AudioPlayback audioPlayback;
 
-    public RepeatAllAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public RepeatAllAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
         audioPlayback = context.getGuildContext().getPlayback();
     }

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/RepeatOneAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/RepeatOneAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.audio.AudioPlayback;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractWidget;
@@ -11,7 +11,7 @@ public class RepeatOneAction extends AbstractWidgetAction {
 
     private final AudioPlayback audioPlayback;
 
-    public RepeatOneAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public RepeatOneAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
         audioPlayback = context.getGuildContext().getPlayback();
     }

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/RewindAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/RewindAction.java
@@ -2,7 +2,7 @@ package net.robinfriedli.aiode.command.widget.actions;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.Aiode;
 import net.robinfriedli.aiode.audio.AudioManager;
 import net.robinfriedli.aiode.audio.AudioPlayback;
@@ -17,7 +17,7 @@ public class RewindAction extends AbstractWidgetAction {
     private final AudioPlayback audioPlayback;
     private final AudioManager audioManager;
 
-    public RewindAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public RewindAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
         audioPlayback = getContext().getGuildContext().getPlayback();
         audioManager = Aiode.get().getAudioManager();

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/ShuffleAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/ShuffleAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.audio.AudioPlayback;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractWidget;
@@ -11,7 +11,7 @@ public class ShuffleAction extends AbstractWidgetAction {
 
     private final AudioPlayback audioPlayback;
 
-    public ShuffleAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public ShuffleAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
         audioPlayback = context.getGuildContext().getPlayback();
     }

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/SkipAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/SkipAction.java
@@ -2,7 +2,7 @@ package net.robinfriedli.aiode.command.widget.actions;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.Aiode;
 import net.robinfriedli.aiode.audio.AudioManager;
 import net.robinfriedli.aiode.audio.AudioPlayback;
@@ -17,7 +17,7 @@ public class SkipAction extends AbstractWidgetAction {
     private final AudioPlayback audioPlayback;
     private final AudioManager audioManager;
 
-    public SkipAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public SkipAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
         audioPlayback = getContext().getGuildContext().getPlayback();
         audioManager = Aiode.get().getAudioManager();

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/VolumeDownAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/VolumeDownAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.audio.AudioPlayback;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractWidget;
@@ -13,7 +13,7 @@ import net.robinfriedli.aiode.util.EmojiConstants;
  */
 public class VolumeDownAction extends AbstractWidgetAction {
 
-    public VolumeDownAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public VolumeDownAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/actions/VolumeUpAction.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/actions/VolumeUpAction.java
@@ -1,6 +1,6 @@
 package net.robinfriedli.aiode.command.widget.actions;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.audio.AudioPlayback;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractWidget;
@@ -13,7 +13,7 @@ import net.robinfriedli.aiode.util.EmojiConstants;
  */
 public class VolumeUpAction extends AbstractWidgetAction {
 
-    public VolumeUpAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
+    public VolumeUpAction(String identifier, String emojiUnicode, boolean resetRequired, CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition widgetActionDefinition) {
         super(identifier, emojiUnicode, resetRequired, context, widget, event, widgetActionDefinition);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/widgets/NowPlayingWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/widgets/NowPlayingWidget.java
@@ -2,6 +2,7 @@ package net.robinfriedli.aiode.command.widget.widgets;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.robinfriedli.aiode.command.widget.AbstractDecoratingWidget;
 import net.robinfriedli.aiode.command.widget.WidgetRegistry;
 
@@ -12,10 +13,11 @@ public class NowPlayingWidget extends AbstractDecoratingWidget {
     }
 
     @Override
-    public void reset() {
+    public MessageEmbed reset() {
         setMessageDeleted(true);
         // if a different track is played after using the skip or rewind action, the old "now playing" message will get
         // deleted by the AudioPlayback anyway
+        return null;
     }
 
     @Override

--- a/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PaginatedMessageEmbedWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PaginatedMessageEmbedWidget.java
@@ -1,0 +1,39 @@
+package net.robinfriedli.aiode.command.widget.widgets;
+
+import java.util.List;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.robinfriedli.aiode.command.widget.AbstractPaginationWidget;
+import net.robinfriedli.aiode.command.widget.WidgetRegistry;
+import org.jetbrains.annotations.Nullable;
+
+public class PaginatedMessageEmbedWidget extends AbstractPaginationWidget<MessageEmbed.Field> {
+
+    private final MessageEmbed messageEmbed;
+
+    public PaginatedMessageEmbedWidget(WidgetRegistry widgetRegistry, Guild guild, MessageChannel channel, MessageEmbed messageEmbed) {
+        super(widgetRegistry, guild, channel, messageEmbed.getFields(), 25);
+        this.messageEmbed = messageEmbed;
+    }
+
+    @Override
+    protected String getTitle() {
+        return messageEmbed.getTitle();
+    }
+
+    @Nullable
+    @Override
+    protected String getDescription() {
+        return messageEmbed.getDescription();
+    }
+
+    @Override
+    protected void handlePage(EmbedBuilder embedBuilder, List<MessageEmbed.Field> page) {
+        for (MessageEmbed.Field field : page) {
+            embedBuilder.addField(field);
+        }
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PermissionListPaginationWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PermissionListPaginationWidget.java
@@ -15,7 +15,7 @@ import net.robinfriedli.aiode.util.EmbedTable;
 import net.robinfriedli.stringlist.StringList;
 import org.jetbrains.annotations.Nullable;
 
-public class PermissionListPaginationWidget extends AbstractPaginationWidget<PermissionTarget> {
+public class PermissionListPaginationWidget extends AbstractPaginationWidget.EmbedTablePaginationWidget<PermissionTarget> {
 
     private final SecurityManager securityManager;
 
@@ -26,8 +26,8 @@ public class PermissionListPaginationWidget extends AbstractPaginationWidget<Per
 
     @SuppressWarnings("unchecked")
     @Override
-    protected AbstractPaginationWidget.Column<PermissionTarget>[] getColumns() {
-        return new AbstractPaginationWidget.Column[]{
+    protected EmbedTablePaginationWidget.Column<PermissionTarget>[] getColumns() {
+        return new EmbedTablePaginationWidget.Column[]{
             new Column<PermissionTarget>("Permission", permissionTarget -> {
                 int childTargetLevel = 0;
                 PermissionTarget currentParent = permissionTarget.getParentTarget();

--- a/src/main/java/net/robinfriedli/aiode/command/widget/widgets/QueueWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/widgets/QueueWidget.java
@@ -1,17 +1,13 @@
 package net.robinfriedli.aiode.command.widget.widgets;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.robinfriedli.aiode.Aiode;
 import net.robinfriedli.aiode.audio.AudioPlayback;
 import net.robinfriedli.aiode.command.widget.AbstractDecoratingWidget;
 import net.robinfriedli.aiode.command.widget.WidgetRegistry;
-import net.robinfriedli.aiode.discord.DiscordEntity;
 import net.robinfriedli.aiode.discord.MessageService;
 
 public class QueueWidget extends AbstractDecoratingWidget {
@@ -24,15 +20,12 @@ public class QueueWidget extends AbstractDecoratingWidget {
     }
 
     @Override
-    public void reset() {
+    public MessageEmbed reset() {
         MessageService messageService = Aiode.get().getMessageService();
         Guild guild = getGuild().get();
-        MessageChannel channel = getChannel().get();
-        DiscordEntity.Message message = getMessage();
 
         EmbedBuilder embedBuilder = audioPlayback.getAudioQueue().buildMessageEmbed(audioPlayback, guild);
-        MessageEmbed messageEmbed = messageService.buildEmbed(embedBuilder);
-        messageService.executeMessageChannelAction(channel, c -> c.editMessageById(message.getId(), MessageEditData.fromEmbeds(messageEmbed)), Permission.MESSAGE_EMBED_LINKS);
+        return messageService.buildEmbed(embedBuilder);
     }
 
 }

--- a/src/main/java/net/robinfriedli/aiode/cron/tasks/DestroyInactiveWidgetsTask.java
+++ b/src/main/java/net/robinfriedli/aiode/cron/tasks/DestroyInactiveWidgetsTask.java
@@ -1,0 +1,54 @@
+package net.robinfriedli.aiode.cron.tasks;
+
+import java.time.Duration;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
+import net.robinfriedli.aiode.Aiode;
+import net.robinfriedli.aiode.command.widget.AbstractWidget;
+import net.robinfriedli.aiode.command.widget.WidgetRegistry;
+import net.robinfriedli.aiode.cron.AbstractCronTask;
+import net.robinfriedli.aiode.discord.GuildContext;
+import net.robinfriedli.aiode.discord.GuildManager;
+import net.robinfriedli.aiode.function.RateLimitInvoker;
+import net.robinfriedli.exec.Mode;
+import org.quartz.JobExecutionContext;
+
+public class DestroyInactiveWidgetsTask extends AbstractCronTask {
+
+    private static final RateLimitInvoker WIDGET_DESTROY_RATE_LIMITED = new RateLimitInvoker("inactive_widget_destruction", 5, Duration.ofSeconds(1));
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    protected void run(JobExecutionContext jobExecutionContext) throws Exception {
+        Aiode aiode = Aiode.get();
+        GuildManager guildManager = aiode.getGuildManager();
+
+        Set<AbstractWidget> widgetsToDestroy = Sets.newHashSet();
+        for (GuildContext guildContext : guildManager.getGuildContexts()) {
+            WidgetRegistry widgetRegistry = guildContext.getWidgetRegistry();
+            widgetRegistry.withActiveWidgets(activeWidgets ->
+                activeWidgets.stream().filter(AbstractWidget::isInactive).forEach(widgetsToDestroy::add)
+            );
+        }
+
+        if (!widgetsToDestroy.isEmpty()) {
+            logger.info("Found {} inactive widgets to destroy", widgetsToDestroy.size());
+            for (AbstractWidget widgetToDestroy : widgetsToDestroy) {
+                if (widgetToDestroy.isInactive()) {
+                    WIDGET_DESTROY_RATE_LIMITED.invokeLimited(widgetToDestroy::destroy);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Mode getMode() {
+        return Mode.create();
+    }
+
+}

--- a/src/main/java/net/robinfriedli/aiode/entities/xml/WidgetContribution.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/xml/WidgetContribution.java
@@ -5,11 +5,12 @@ import java.lang.reflect.InvocationTargetException;
 
 import javax.annotation.Nullable;
 
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.robinfriedli.aiode.command.CommandContext;
 import net.robinfriedli.aiode.command.widget.AbstractWidget;
 import net.robinfriedli.aiode.command.widget.AbstractWidgetAction;
 import net.robinfriedli.aiode.command.widget.WidgetManager;
+import net.robinfriedli.jxp.api.AbstractXmlElement;
 import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
@@ -28,8 +29,24 @@ public class WidgetContribution extends GenericClassContribution<AbstractWidget>
         return getAttribute("implementation").getValue();
     }
 
-    public boolean shouldClearReactionOnReset() {
-        return getAttribute("clearReactionOnReset").getBool();
+    public boolean allowMultipleActive() {
+        return getAttribute("allowMultipleActive").getBool();
+    }
+
+    public static class WidgetActionRow extends AbstractXmlElement {
+
+        // invoked by JXP
+        @SuppressWarnings("unused")
+        public WidgetActionRow(Element element, NodeList subElements, Context context) {
+            super(element, subElements, context);
+        }
+
+        @Nullable
+        @Override
+        public String getId() {
+            return null;
+        }
+
     }
 
     public static class WidgetActionContribution extends GenericClassContribution<AbstractWidgetAction> {
@@ -54,7 +71,7 @@ public class WidgetContribution extends GenericClassContribution<AbstractWidget>
             return getAttribute("emojiUnicode").getValue();
         }
 
-        public AbstractWidgetAction instantiate(CommandContext context, AbstractWidget widget, MessageReactionAddEvent event, WidgetManager.WidgetActionDefinition definition) {
+        public AbstractWidgetAction instantiate(CommandContext context, AbstractWidget widget, ButtonInteractionEvent event, WidgetManager.WidgetActionDefinition definition) {
             Class<? extends AbstractWidgetAction> implementationClass = getImplementationClass();
             Constructor<? extends AbstractWidgetAction> constructor;
             try {
@@ -64,7 +81,7 @@ public class WidgetContribution extends GenericClassContribution<AbstractWidget>
                     Boolean.TYPE,
                     CommandContext.class,
                     AbstractWidget.class,
-                    MessageReactionAddEvent.class,
+                    ButtonInteractionEvent.class,
                     WidgetManager.WidgetActionDefinition.class
                 );
             } catch (NoSuchMethodException e) {

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/AudioQueue.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/AudioQueue.kt
@@ -664,8 +664,8 @@ class AudioQueue(val maxSize: Int?) {
 
     private fun appendPlayable(trackListBuilder: StringBuilder, playable: Playable) {
         playable.fetch()
-        var display = playable.display(2, TimeUnit.SECONDS)
-        val durationMs = playable.durationMs(2, TimeUnit.SECONDS)
+        var display = playable.display(100, TimeUnit.MILLISECONDS)
+        val durationMs = playable.durationMs(100, TimeUnit.MILLISECONDS)
         if (display.length > 100) {
             display = display.substring(0, 95) + "[...]"
         }

--- a/src/main/resources/schemas/widgetSchema.xsd
+++ b/src/main/resources/schemas/widgetSchema.xsd
@@ -9,10 +9,18 @@
   </xs:complexType>
   <xs:complexType name="widget">
     <xs:sequence>
-      <xs:element name="widgetAction" type="widgetAction"/>
+      <xs:element name="action-row" type="action-row"/>
     </xs:sequence>
     <xs:attribute name="implementation" type="xs:string"/>
-    <xs:attribute name="clearReactionOnReset" type="xs:boolean" default="false"/>
+    <xs:attribute name="allowMultipleActive" type="xs:boolean" default="false">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">
+          Allow multiple instances of this widget class to be active at the same time within the same guild. If false,
+          creating a new widget of this class destroys the previous widget.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="keepMessageOnDestroy" type="xs:boolean" default="false"/>
   </xs:complexType>
   <xs:complexType name="widgetAction">
     <xs:attribute name="identifier" type="xs:string"/>
@@ -20,6 +28,11 @@
     <xs:attribute name="resetRequired" type="xs:boolean"/>
     <xs:attribute name="implementation" type="xs:string"/>
     <xs:attribute name="displayPredicate" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="action-row">
+    <xs:sequence>
+      <xs:element name="widgetAction" type="widgetAction"/>
+    </xs:sequence>
   </xs:complexType>
 
 </xs:schema>

--- a/src/main/resources/xml-contributions/cronJobs.xml
+++ b/src/main/resources/xml-contributions/cronJobs.xml
@@ -6,4 +6,5 @@
   <cronJob id="deleteGrantedRolesForDeletedRoles" cron="0 0 */1 * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.DeleteGrantedRolesForDeletedRolesTask"/>
   <cronJob id="resetCurrentYouTubeQuota" cron="0 0 0 * * ? *" timeZone="PST" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.cron.tasks.ResetCurrentYouTubeQuotaTask"/>
   <cronJob id="refreshPersistentGlobalCharts" cron="0 0 6 * * ? *" mainInstanceOnly="true" implementation="net.robinfriedli.aiode.cron.tasks.RefreshPersistentGlobalChartsTask"/>
+  <cronJob id="inactiveWidgetsCleanup" cron="0 */10 * * * ? *" implementation="net.robinfriedli.aiode.cron.tasks.DestroyInactiveWidgetsTask"/>
 </cronJobs>

--- a/src/main/resources/xml-contributions/widgets.xml
+++ b/src/main/resources/xml-contributions/widgets.xml
@@ -1,24 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <widgets xmlns="widgetSpace">
   <widget implementation="net.robinfriedli.aiode.command.widget.widgets.NowPlayingWidget">
-    <widgetAction identifier="rewind" emojiUnicode="⏮" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RewindAction"/>
-    <widgetAction identifier="play" emojiUnicode="⏯" resetRequired="false" implementation="net.robinfriedli.aiode.command.widget.actions.PlayPauseAction"/>
-    <widgetAction identifier="skip" emojiUnicode="⏭" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.SkipAction"/>
+    <action-row>
+      <widgetAction identifier="rewind" emojiUnicode="⏮" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RewindAction"/>
+      <widgetAction identifier="play" emojiUnicode="⏯" resetRequired="false" implementation="net.robinfriedli.aiode.command.widget.actions.PlayPauseAction"/>
+      <widgetAction identifier="skip" emojiUnicode="⏭" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.SkipAction"/>
+    </action-row>
   </widget>
-  <widget clearReactionOnReset="true" implementation="net.robinfriedli.aiode.command.widget.widgets.QueueWidget">
-    <widgetAction identifier="shuffle" emojiUnicode="🔀" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.ShuffleAction"/>
-    <widgetAction identifier="rewind" emojiUnicode="⏮" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RewindAction"/>
-    <widgetAction identifier="play" emojiUnicode="⏯" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.PlayPauseAction"/>
-    <widgetAction identifier="skip" emojiUnicode="⏭" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.SkipAction"/>
-    <widgetAction identifier="repeat" emojiUnicode="🔁" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RepeatAllAction"/>
-    <widgetAction identifier="repeat" emojiUnicode="🔂" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RepeatOneAction"/>
-    <widgetAction identifier="volume" emojiUnicode="🔉" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.VolumeDownAction"/>
-    <widgetAction identifier="volume" emojiUnicode="🔊" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.VolumeUpAction"/>
+  <widget implementation="net.robinfriedli.aiode.command.widget.widgets.QueueWidget">
+    <action-row>
+      <widgetAction identifier="shuffle" emojiUnicode="🔀" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.ShuffleAction"/>
+      <widgetAction identifier="rewind" emojiUnicode="⏮" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RewindAction"/>
+      <widgetAction identifier="play" emojiUnicode="⏯" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.PlayPauseAction"/>
+      <widgetAction identifier="skip" emojiUnicode="⏭" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.SkipAction"/>
+    </action-row>
+    <action-row>
+      <widgetAction identifier="repeat-all" emojiUnicode="🔁" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RepeatAllAction"/>
+      <widgetAction identifier="repeat-one" emojiUnicode="🔂" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.RepeatOneAction"/>
+      <widgetAction identifier="volume-down" emojiUnicode="🔉" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.VolumeDownAction"/>
+      <widgetAction identifier="volume-up" emojiUnicode="🔊" resetRequired="true" implementation="net.robinfriedli.aiode.command.widget.actions.VolumeUpAction"/>
+    </action-row>
   </widget>
-  <widget clearReactionOnReset="true" implementation="net.robinfriedli.aiode.command.widget.widgets.PermissionListPaginationWidget">
-    <widgetAction identifier="firstPage" emojiUnicode="⏮" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.FirstPageAction"/>
-    <widgetAction identifier="prevPage" emojiUnicode="⏪" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.PrevPageAction"/>
-    <widgetAction identifier="nextPage" emojiUnicode="⏩" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.NextPageAction"/>
-    <widgetAction identifier="lastPage" emojiUnicode="⏭" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.LastPageAction"/>
+  <widget implementation="net.robinfriedli.aiode.command.widget.widgets.PermissionListPaginationWidget">
+    <action-row>
+      <widgetAction identifier="firstPage" emojiUnicode="⏮" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.FirstPageAction"/>
+      <widgetAction identifier="prevPage" emojiUnicode="⏪" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.PrevPageAction"/>
+      <widgetAction identifier="nextPage" emojiUnicode="⏩" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.NextPageAction"/>
+      <widgetAction identifier="lastPage" emojiUnicode="⏭" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.LastPageAction"/>
+    </action-row>
+  </widget>
+  <widget allowMultipleActive="true" keepMessageOnDestroy="true" implementation="net.robinfriedli.aiode.command.widget.widgets.PaginatedMessageEmbedWidget">
+    <action-row>
+      <widgetAction identifier="firstPage" emojiUnicode="⏮" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.FirstPageAction"/>
+      <widgetAction identifier="prevPage" emojiUnicode="⏪" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.PrevPageAction"/>
+      <widgetAction identifier="nextPage" emojiUnicode="⏩" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.NextPageAction"/>
+      <widgetAction identifier="lastPage" emojiUnicode="⏭" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.LastPageAction"/>
+    </action-row>
   </widget>
 </widgets>


### PR DESCRIPTION
- use button interactions instead of reactions
- implement PaginatedMessageEmbedWidget to automatically add pagination to MessageEmbeds with too many fields
- use PaginatedMessageEmbedWidget for help command
  - queue command help had more than 25 fields
- implement DestroyInactiveWidgetsTask to periodically remove inactive widgets
- organise widget actions in rows
- add option to allow several instances of the same widget to be active at the same time
- add option to keep the message when destroying the widget, only removing the action rows
- use lower timeouts when fetching the display of queue items to ensure that widget actions that reset the queue widget don't take longer than 3 seconds, exceeding the maximum duration for the interaction to succeed