### PR TITLE
implement AutoQueueModeProperty

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/discord/property/properties/AutoQueueModeProperty.java
+++ b/src/main/java/net/robinfriedli/aiode/discord/property/properties/AutoQueueModeProperty.java
@@ -1,0 +1,59 @@
+package net.robinfriedli.aiode.discord.property.properties;
+
+import net.robinfriedli.aiode.discord.property.AbstractGuildProperty;
+import net.robinfriedli.aiode.entities.GuildSpecification;
+import net.robinfriedli.aiode.entities.xml.GuildPropertyContribution;
+import net.robinfriedli.aiode.exceptions.InvalidPropertyValueException;
+
+public class AutoQueueModeProperty extends AbstractGuildProperty {
+
+    public AutoQueueModeProperty(GuildPropertyContribution contribution) {
+        super(contribution);
+    }
+
+    @Override
+    public void validate(Object state) {
+    }
+
+    @Override
+    public Object process(String input) {
+        String trimmedInput = input.trim();
+        if (trimmedInput.equalsIgnoreCase("off")) {
+            return 0;
+        } else if (trimmedInput.equalsIgnoreCase("queue next")) {
+            return 1;
+        } else if (trimmedInput.equalsIgnoreCase("queue last")) {
+            return 2;
+        } else {
+            throw new InvalidPropertyValueException("Invalid auto queue mode");
+        }
+    }
+
+    @Override
+    public void setValue(String value, GuildSpecification guildSpecification) {
+        guildSpecification.setAutoQueueMode((Integer) process(value));
+    }
+
+    @Override
+    public Object extractPersistedValue(GuildSpecification guildSpecification) {
+        return guildSpecification.getAutoQueueMode();
+    }
+
+    @Override
+    public String display(GuildSpecification guildSpecification) {
+        Object extractPersistedValue = extractPersistedValue(guildSpecification);
+        if (extractPersistedValue instanceof Integer intValue) {
+            if (intValue == 0) {
+                return "off";
+            } else if (intValue == 1) {
+                return "queue next";
+            } else if (intValue == 2) {
+                return "queue last";
+            } else {
+                throw new IllegalStateException("Unknown auto queue mode: " + intValue);
+            }
+        } else {
+            return "Not Set";
+        }
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/entities/GuildSpecification.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/GuildSpecification.java
@@ -58,6 +58,8 @@ public class GuildSpecification implements Serializable {
     private String defaultTextChannelId;
     @Column(name = "default_volume")
     private Integer defaultVolume;
+    @Column(name = "auto_queue_mode")
+    private Integer autoQueueMode;
     @Column(name = "enable_scripting")
     private Boolean enableScripting;
     @OneToMany(mappedBy = "guildSpecification")
@@ -203,6 +205,14 @@ public class GuildSpecification implements Serializable {
 
     public void setDefaultVolume(Integer volume) {
         this.defaultVolume = volume;
+    }
+
+    public Integer getAutoQueueMode() {
+        return autoQueueMode;
+    }
+
+    public void setAutoQueueMode(Integer autoQueueMode) {
+        this.autoQueueMode = autoQueueMode;
     }
 
     public Boolean isEnableScripting() {

--- a/src/main/kotlin/net/robinfriedli/aiode/audio/queue/AudioQueue.kt
+++ b/src/main/kotlin/net/robinfriedli/aiode/audio/queue/AudioQueue.kt
@@ -289,17 +289,17 @@ class AudioQueue(val maxSize: Int?) {
         }
     }
 
-    fun addContainers(containers: List<PlayableContainer<*>>, playableFactory: PlayableFactory, clear: Boolean, insertionIdx: Int? = null) {
+    fun addContainers(containers: List<PlayableContainer<*>>, playableFactory: PlayableFactory, clear: Boolean, insertionIdx: Int? = null): Int {
         val writeLock = lock.writeLock()
         writeLock.lock()
         try {
-            addContainersLocked(containers, playableFactory, clear, insertionIdx)
+            return addContainersLocked(containers, playableFactory, clear, insertionIdx)
         } finally {
             writeLock.unlock()
         }
     }
 
-    fun addContainersLocked(containers: List<PlayableContainer<*>>, playableFactory: PlayableFactory, clear: Boolean, insertionIdx: Int? = null) {
+    fun addContainersLocked(containers: List<PlayableContainer<*>>, playableFactory: PlayableFactory, clear: Boolean, insertionIdx: Int? = null): Int {
         val queueFragments: MutableList<QueueFragment> = ArrayList()
         for (playableContainer in containers) {
             val queueFragment = playableContainer.createQueueFragment(playableFactory, this)
@@ -308,6 +308,7 @@ class AudioQueue(val maxSize: Int?) {
             }
         }
 
+        var loadedAmount = 0
         if (queueFragments.isNotEmpty()) {
             if (clear) {
                 doClear(false)
@@ -318,10 +319,13 @@ class AudioQueue(val maxSize: Int?) {
                 } else {
                     size
                 }, queueFragment)
+                loadedAmount += queueFragment.size()
             }
         } else {
             throw NoResultsFoundException("No results found")
         }
+
+        return loadedAmount
     }
 
     fun remove(fromIdx: Int, toIdx: Int): Int {

--- a/src/main/resources/liquibase/dbchangelog.xml
+++ b/src/main/resources/liquibase/dbchangelog.xml
@@ -1041,4 +1041,9 @@ See application.properties -> spring.liquibase.contexts
       <column name="default_volume" type="int4"/>
     </addColumn>
   </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1690297557464-1">
+    <addColumn tableName="guild_specification">
+      <column name="auto_queue_mode" type="int4"/>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/xml-contributions/guildProperties.xml
+++ b/src/main/resources/xml-contributions/guildProperties.xml
@@ -29,4 +29,9 @@
     <acceptedValue>true</acceptedValue>
     <acceptedValue>false</acceptedValue>
   </guildProperty>
+  <guildProperty property="autoQueueMode" name="auto queue" defaultValue="queue next" implementation="net.robinfriedli.aiode.discord.property.properties.AutoQueueModeProperty" updateMessageScript="def strValue; if (value == 0) { strValue = 'off' } else if (value == 1) { strValue = 'queue next' } else if (value == 2) { strValue = 'queue last' } else { value.toString() }; return String.format(&quot;Set auto queue mode to '%s'&quot;, strValue)" description="Change the auto queue behaviour when using a play command while the bot is already playing. 'queue next' means the tracks are inserted after the current track (this is the default), 'queue last' means the tracks are appended to the end of the queue, 'off' means auto queue is disabled and the tracks are played immediately, replacing the current queue.">
+    <acceptedValue>off</acceptedValue>
+    <acceptedValue>queue next</acceptedValue>
+    <acceptedValue>queue last</acceptedValue>
+  </guildProperty>
 </guildProperties>


### PR DESCRIPTION
- add the following options
  - queue next (default): inserts the tracks after the current position - if paused, iterate to the first inserted track and resume playback - if stopped, insert ahead of the current track and start playback
  - off: auto queue is off, enabling the original behaviour where the play command replaces the queue
  - queue last: add tracks to the end of the queue
- adjust AudioQueue#addContainers to return amount of adde tracks