### PR TITLE
overhaul VersionUpdateAlertTask

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/boot/tasks/VersionUpdateAlertTask.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/tasks/VersionUpdateAlertTask.java
@@ -1,9 +1,11 @@
 package net.robinfriedli.aiode.boot.tasks;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -16,16 +18,18 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.robinfriedli.aiode.boot.StartupTask;
 import net.robinfriedli.aiode.boot.VersionManager;
 import net.robinfriedli.aiode.concurrent.LoggingThreadFactory;
+import net.robinfriedli.aiode.discord.GuildContext;
+import net.robinfriedli.aiode.discord.GuildManager;
 import net.robinfriedli.aiode.discord.MessageService;
+import net.robinfriedli.aiode.entities.GuildSpecification;
 import net.robinfriedli.aiode.entities.xml.StartupTaskContribution;
 import net.robinfriedli.aiode.entities.xml.Version;
 import net.robinfriedli.aiode.function.CheckedConsumer;
 import net.robinfriedli.aiode.persist.StaticSessionProvider;
+import net.robinfriedli.aiode.persist.qb.QueryBuilderFactory;
 import net.robinfriedli.jxp.api.XmlElement;
-import net.robinfriedli.jxp.persist.Context;
 import org.hibernate.Session;
 
-import static net.robinfriedli.aiode.boot.VersionManager.Conditions.*;
 import static net.robinfriedli.jxp.queries.Conditions.*;
 
 /**
@@ -40,16 +44,20 @@ public class VersionUpdateAlertTask implements StartupTask {
         0,
         new LoggingThreadFactory("version-update-dispatch")
     );
-    // since the task is run for each shard separately and the launched flag gets set to true the first time,
-    // this flag is used to remember whether there has been an update
-    private static boolean UPDATED = false;
     private static int OFFSET = 0;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final GuildManager guildManager;
     private final MessageService messageService;
+    private final QueryBuilderFactory queryBuilderFactory;
     private final StartupTaskContribution contribution;
     private final VersionManager versionManager;
 
-    public VersionUpdateAlertTask(MessageService messageService, StartupTaskContribution contribution, VersionManager versionManager) {
+    public VersionUpdateAlertTask(GuildManager guildManager, MessageService messageService, QueryBuilderFactory queryBuilderFactory, StartupTaskContribution contribution, VersionManager versionManager) {
+        this.guildManager = guildManager;
         this.messageService = messageService;
+        this.queryBuilderFactory = queryBuilderFactory;
         this.contribution = contribution;
         this.versionManager = versionManager;
     }
@@ -61,59 +69,76 @@ public class VersionUpdateAlertTask implements StartupTask {
 
     @Override
     public void perform(@Nullable JDA shard) {
-        Logger logger = LoggerFactory.getLogger(getClass());
         Version versionElem = versionManager.getCurrentVersion();
         if (versionElem != null) {
-            Context context = versionManager.getContext();
-            if (UPDATED || !versionElem.getAttribute("launched").getBool()) {
-                UPDATED = true;
-                if (!(versionElem.hasAttribute("silent") && versionElem.getAttribute("silent").getBool())) {
-                    sendUpdateAlert(context, versionElem, shard);
-                }
-
-                context.invoke(() -> versionElem.setAttribute("launched", true));
+            if (!versionElem.isSilentUpdate()) {
+                sendUpdateAlert(versionElem, shard);
             }
         } else {
             logger.warn("Current version has no version element in versions.xml");
         }
     }
 
-    private void sendUpdateAlert(Context context, Version versionElem, JDA shard) {
-        List<XmlElement> lowerLaunchedVersions = context.query(and(
-            tagName("version"),
-            attribute("launched").is(true),
-            lowerVersionThan(versionElem.getVersion())
-        )).collect();
-        if (!lowerLaunchedVersions.isEmpty()) {
-            String message = "Aiode has been updated to " + versionElem.getVersion() + ". [Check the releases here]("
-                + "https://github.com/robinfriedli/botify/releases)";
-            EmbedBuilder embedBuilder = new EmbedBuilder();
-            embedBuilder.setTitle("Update");
-            embedBuilder.setDescription(message);
+    private void sendUpdateAlert(Version versionElem, JDA shard) {
+        String version = versionElem.getVersion();
+        String message = "Aiode has been updated to " + version + ". [Check the releases here]("
+            + "https://github.com/robinfriedli/botify/releases)";
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.setTitle("Update");
+        embedBuilder.setDescription(message);
 
-            List<XmlElement> features = versionElem.query(tagName("feature")).collect();
-            if (!features.isEmpty()) {
-                embedBuilder.addField("**Features**", "Changes in this update", false);
-                for (XmlElement feature : features) {
-                    embedBuilder.addField(feature.getAttribute("title").getValue(), feature.getTextContent(), false);
-                }
+        List<XmlElement> features = versionElem.query(tagName("feature")).collect();
+        if (!features.isEmpty()) {
+            embedBuilder.addField("**Features**", "Changes in this update", false);
+            for (XmlElement feature : features) {
+                embedBuilder.addField(feature.getAttribute("title").getValue(), feature.getTextContent(), false);
             }
+        }
 
-            List<Guild> guilds = shard.getGuilds();
-            long delaySecs = OFFSET++ * (guilds.size() / MESSAGES_PER_SECOND);
-            if (delaySecs > 0) {
-                delaySecs += 10;
-            }
+        List<Guild> guilds = shard.getGuilds();
 
-            MESSAGE_DISPATCH.schedule(() -> {
-                // use a lock in case one shard has fewer guilds and thus did not calculate enough of a delay to align
-                // with the other shards
-                synchronized (DISPATCH_LOCK) {
+        Long guildsToUpdate = StaticSessionProvider.invokeWithSession(session -> queryBuilderFactory
+            .count(GuildSpecification.class)
+            .where((cb, root) -> cb.and(
+                cb.or(
+                    cb.notEqual(root.get("versionUpdateAlertSent"), version),
+                    cb.isNull(root.get("versionUpdateAlertSent"))
+                ),
+                root.get("guildId").in(guilds.stream().map(Guild::getId).collect(Collectors.toSet()))
+            ))
+            .build(session)
+            .uniqueResult()
+        );
+
+        if (guildsToUpdate == 0) {
+            return;
+        }
+
+        int delaySecs = OFFSET++ * (guilds.size() / MESSAGES_PER_SECOND);
+        if (delaySecs > 0) {
+            delaySecs += 10;
+        }
+
+        logger.info("Scheduling dispatch of version update notification for {} guilds after a delay of {} seconds", guilds.size(), delaySecs);
+
+        MESSAGE_DISPATCH.schedule(() -> {
+            // use a lock in case one shard has fewer guilds and thus did not calculate enough of a delay to align
+            // with the other shards
+            synchronized (DISPATCH_LOCK) {
+                try {
                     // setup current thread session and handle all guilds within one session instead of opening a new session for each
                     StaticSessionProvider.consumeSession((CheckedConsumer<Session>) session -> {
                         int counter = 0;
                         long currentTimeMillis = System.currentTimeMillis();
                         for (Guild guild : guilds) {
+                            GuildContext guildContext = guildManager.getContextForGuild(guild);
+                            GuildSpecification guildSpecification = guildContext.getSpecification(session);
+                            if (Objects.equals(guildSpecification.getVersionUpdateAlertSent(), version)) {
+                                continue;
+                            } else {
+                                guildSpecification.setVersionUpdateAlertSent(version);
+                            }
+
                             messageService.sendWithLogo(embedBuilder, guild);
 
                             if (++counter % MESSAGES_PER_SECOND == 0) {
@@ -125,10 +150,11 @@ public class VersionUpdateAlertTask implements StartupTask {
                             }
                         }
                     });
+                } catch (Exception e) {
+                    logger.error("Error sending version update alert", e);
                 }
-            }, delaySecs, TimeUnit.SECONDS);
-
-        }
+            }
+        }, delaySecs, TimeUnit.SECONDS);
     }
 
 }

--- a/src/main/java/net/robinfriedli/aiode/entities/GuildSpecification.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/GuildSpecification.java
@@ -62,6 +62,8 @@ public class GuildSpecification implements Serializable {
     private Integer autoQueueMode;
     @Column(name = "enable_scripting")
     private Boolean enableScripting;
+    @Column(name = "version_update_alert_sent")
+    private String versionUpdateAlertSent;
     @OneToMany(mappedBy = "guildSpecification")
     private Set<AccessConfiguration> accessConfigurations = Sets.newHashSet();
 
@@ -221,5 +223,13 @@ public class GuildSpecification implements Serializable {
 
     public void setEnableScripting(Boolean enableScripting) {
         this.enableScripting = enableScripting;
+    }
+
+    public String getVersionUpdateAlertSent() {
+        return versionUpdateAlertSent;
+    }
+
+    public void setVersionUpdateAlertSent(String versionUpdateAlertSent) {
+        this.versionUpdateAlertSent = versionUpdateAlertSent;
     }
 }

--- a/src/main/java/net/robinfriedli/aiode/entities/xml/Version.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/xml/Version.java
@@ -27,10 +27,6 @@ public class Version extends AbstractXmlElement implements Comparable<Version> {
         return getAttribute("version").getValue();
     }
 
-    public boolean isLaunched() {
-        return getAttribute("launched").getBool();
-    }
-
     public boolean isSilentUpdate() {
         return getAttribute("silent").getBool();
     }

--- a/src/main/resources/liquibase/dbchangelog.xml
+++ b/src/main/resources/liquibase/dbchangelog.xml
@@ -1066,4 +1066,9 @@ See application.properties -> spring.liquibase.contexts
       <column name="LOWER(name)"/>
     </createIndex>
   </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1690376893928-1">
+    <addColumn tableName="guild_specification">
+      <column name="version_update_alert_sent" type="varchar(255)"/>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/versions.xml
+++ b/versions.xml
@@ -1,51 +1,51 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <versions xmlns="versionSpace">
-  <version launched="false" version="2.2">
+  <version version="2.2">
     <feature title="Queue insertion and removal">Added the $insert and $remove arguments to the queue command to remove the tracks at the given index range from the queue or insert tracks at the given position. The $insert argument inserts the tracks right after the current track by default (or if the $next argument is used), you can add the $at argument to insert the tracks at any position relative to the current position in the queue (e.g. `queue $insert $at=2 numb` inserts the track 'numb' after the next track in the queue).</feature>
-    <feature title="auto queue">Added the 'auto queue' guild property to control the behaviour of the bot when using the play command while already playing something else. This is accessible via the property command with the following options: 'queue next' -> insert the tracks into the queue after the current track, this is now the default / 'queue last' -> append the tracks to the end of the queue / 'off' -> enables the original behaviour the play command replaces the current queue</feature>
+    <feature title="auto queue">Added the 'auto queue' guild property to control the behaviour of the bot when using the play command while already playing something else. This is accessible via the property command with the following options: 'queue next' -&gt; insert the tracks into the queue after the current track, this is now the default / 'queue last' -&gt; append the tracks to the end of the queue / 'off' -&gt; enables the original behaviour the play command replaces the current queue</feature>
     <feature title="New widget interactions">Using Discord's button interaction system rather than reactions for widgets, enabling them to be displayed a lot faster (instead of adding reactions one by one) and adding multiple rows. The queue widget has been extended with volume controls.</feature>
     <feature title="Default volume property">The default volume of 100 can now be changed using the 'default volume' property of the property command.</feature>
     <feature title="Improved charts command">The charts command has been overhauled, much improving performance and adding user specific charts. Global charts are now only refreshed once per day instead of on demand.</feature>
     <feature title="Improved performance">Performance of many database queries has been improved significantly with additional indexes.</feature>
   </version>
-  <version launched="true" version="2.1">
+  <version version="2.1">
     <feature title="Slash command migration">As message content is now becoming a privileged intent, bots can only read message content when mentioned directly. This means prefixes will no longer work, at least until the bot is authorized for the intent. Using commands now only works via slash commands or when mentioning the bot as a prefix (e.g. `@aiode play numb`).</feature>
     <feature title="Queue system rework">The queue system received a substantial backend rework, enabling support for future features, such as inserting / removing items everywhere in the queue.</feature>
   </version>
-  <version launched="true" version="2.0">
+  <version version="2.0">
     <feature title="Scripting sandbox">Implement groovy script command sandbox.</feature>
     <feature title="Backend rework">Rework codebase with spring boot and gradle.</feature>
   </version>
-  <version launched="true" version="1.6.LTS.4">
+  <version version="1.6.LTS.4">
     <feature title="YouTube API quota usage adjustments">Tired of botify reaching the YouTube API quota limit and breaking all YouTube requests? So am I. Botify now calculates the approximate quota usage and stops using the YouTube API wherever possible in exchange for parsing the html response of YouTube pages using lavaplayer when the quota gets low.</feature>
     <feature title="Embed message formatting adjustments">Adjusted the layout of some embed messages to the new discord update.</feature>
     <feature title="Enabled JDA sharding">Added JDA sharding. This was originally intended as a feature for botify 2 but botify is going to reach 2500 guilds, the maximum number of guilds per WebSocket, before then.</feature>
   </version>
-  <version launched="true" version="1.6.LTS">
+  <version version="1.6.LTS">
     <feature>this long-term-support version of botify 1.6 marks the end of development for botify 1 while development shifts to botify 2 featuring a new web client and improved queue management</feature>
     <feature>as an LTS release this version will continue to receive bug fixes even after botify 2 is released</feature>
   </version>
-  <version launched="true" version="1.6.5">
+  <version version="1.6.5">
     <feature>final version of botify 1.6 that offers remaining improvements and optimisations</feature>
   </version>
-  <version launched="true" version="1.6.4">
+  <version version="1.6.4">
     <feature>when searching a Spotify track, botify now automatically picks the best result based on likeness of the track names, track popularity and how popular each artist is in this guild; to get a selection of results like in previous versions you may use the "select" argument</feature>
     <feature>added album covers to the queue and "now playing..." widgets for Spotify tracks</feature>
     <feature>added a periodic task that resets playback settings and queues after an hour of inactivity to preserve resources and ensure long term stability</feature>
     <feature>other improvements and fixes</feature>
   </version>
-  <version launched="true" version="1.6.3">
+  <version version="1.6.3">
     <feature>added synchronise command to sync an external playlist with a botify playlist</feature>
     <feature>added empty command to clear botify playlists</feature>
     <feature>added property to define the default text channel for bot messages</feature>
     <feature>added property to define timeout for automatic deletion of success and common error messages</feature>
     <feature>several improvements and fixes</feature>
   </version>
-  <version launched="true" version="1.6.2.1">
+  <version version="1.6.2.1">
     <feature>fix issue with unavailable Spotify tracks in local playlists</feature>
     <feature>improve concurrent command handling and create abort command to interrupt long commands and cancel queued commands</feature>
   </version>
-  <version launched="true" version="1.6.2">
+  <version version="1.6.2">
     <feature>**new command parser that is smarter at interpreting arguments**
       - makes using arguments less strict and inline arguments may now be used wherever you want in the command and they are treated as regular arguments with the input to their right as value
       - *meaning `insert track $to listName $at position` could now also be written `insert track $at position $to listName` or even `insert $to=listName $at=position track`*
@@ -58,31 +58,31 @@
     <feature>**help command examples now use the custom prefixes**</feature>
     <feature>**upgrade to JDA 4**</feature>
   </version>
-  <version launched="true" silent="true" version="1.6.1.4">
+  <version silent="true" version="1.6.1.4">
     <feature>make Spotify redirect smarter</feature>
     <feature>add some handling for rare cases when PlaylistTracks have a null track</feature>
   </version>
-  <version launched="true" silent="true" version="1.6.1.3">
+  <version silent="true" version="1.6.1.3">
     <feature>update lavaplayer dependency to fix loading some YouTube videos</feature>
   </version>
-  <version launched="true" silent="true" version="1.6.1.2">
+  <version silent="true" version="1.6.1.2">
     <feature>enable silent updates</feature>
     <feature>fix export command</feature>
     <feature>fix Playable#matches</feature>
     <feature>improve upload command</feature>
   </version>
-  <version launched="true" version="1.6.1.1">
+  <version version="1.6.1.1">
     <feature>improve and add new admin tools</feature>
     <feature>fix wrong behavior of the play / pause action when the bot left the channel</feature>
     <feature>minor improvements</feature>
   </version>
-  <version launched="true" version="1.6.1">
+  <version version="1.6.1">
     <feature>added charts command</feature>
     <feature>added properties to select the default source (Spotify, YouTube, local) when searching a track or list</feature>
     <feature>added property to toggle the auto pause feature</feature>
     <feature>various bug fixes and improvements</feature>
   </version>
-  <version launched="true" version="1.6">
+  <version version="1.6">
     <feature>added customisable properties to change the color scheme or toggle playback notifications using the new property command</feature>
     <feature>added a whole new category of commands for bot admins to manage the bot</feature>
     <feature>reworked the permission command to manage several commands at once more easily</feature>
@@ -94,7 +94,7 @@
     <feature>reworked the "own" argument making it work for albums and support Spotify query syntax</feature>
     <feature>major rework of the code base providing several fixes and improvements</feature>
   </version>
-  <version launched="true" version="1.5.2">
+  <version version="1.5.2">
     <feature>add new commands to manage playlists: move and insert</feature>
     <feature>make Spotify to YouTube redirect smarter</feature>
     <feature>allow preset names to start with command names without conflict</feature>
@@ -104,16 +104,16 @@
     <feature>fix old widget messages not being deleted</feature>
     <feature>raise bot name length limit to 20</feature>
   </version>
-  <version launched="true" version="1.5.1.2">
+  <version version="1.5.1.2">
     <feature>fix presets containing a single quote</feature>
   </version>
-  <version launched="true" version="1.5.1.1">
+  <version version="1.5.1.1">
     <feature>make preset search case insensitive</feature>
     <feature>fix commands not being parsed correctly due to case sensitivity</feature>
     <feature>fix bug in search command when searching for Spotify albums / playlists with less than 5 tracks</feature>
     <feature>correct some typos</feature>
   </version>
-  <version launched="true" version="1.5.1">
+  <version version="1.5.1">
     <feature>command presets</feature>
     <feature>volume command</feature>
     <feature>customisable command prefix separate from bot name</feature>
@@ -126,13 +126,13 @@
     <feature>the queue command now shows the playback settings even when the queue is empty</feature>
     <feature>automatically unpause playback when playing a different track</feature>
   </version>
-  <version launched="true" version="1.5.0.1"/>
-  <version launched="true" version="1.5"/>
-  <version launched="true" version="1.4.2"/>
-  <version launched="true" version="1.4.1"/>
-  <version launched="true" version="1.4"/>
-  <version launched="true" version="1.3"/>
-  <version launched="true" version="1.2"/>
-  <version launched="true" version="1.1"/>
-  <version launched="true" version="1.0"/>
+  <version version="1.5.0.1"/>
+  <version version="1.5"/>
+  <version version="1.4.2"/>
+  <version version="1.4.1"/>
+  <version version="1.4"/>
+  <version version="1.3"/>
+  <version version="1.2"/>
+  <version version="1.1"/>
+  <version version="1.0"/>
 </versions>


### PR DESCRIPTION
- track whether an update notification has been sent for each guild by adding the versionUpdateAlertSent property to the GuildSpecification and set it to the version a notification has been sent for to the corresponding guild (and set it to the current version for new guilds)
- instead of tracking whether a version has been launched by setting the attribute in the versions.xml file and sending a message to all guilds on first startup
- the new method works across restarts and prevents the task from sending the update to the same guild several times if the bot is restarted with the "launched" attribute reset or if a shard reconnects