### PR TITLE
improve pagination widgets

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/command/widget/DynamicEmbedTablePaginationWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/DynamicEmbedTablePaginationWidget.java
@@ -1,0 +1,94 @@
+package net.robinfriedli.aiode.command.widget;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Lists;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+
+public class DynamicEmbedTablePaginationWidget<E> extends EmbedTablePaginationWidget<E> {
+
+    private final String title;
+    @Nullable
+    private final String description;
+    private final Column<E>[] columns;
+    private final List<E> elements;
+
+    public DynamicEmbedTablePaginationWidget(
+        WidgetRegistry widgetRegistry,
+        Guild guild,
+        MessageChannel channel,
+        String title,
+        @Nullable String description,
+        Column<E>[] columns,
+        List<E> elements
+    ) {
+        super(widgetRegistry, guild, channel, null);
+        this.title = title;
+        this.description = description;
+        this.columns = columns;
+        this.elements = elements;
+    }
+
+    @Override
+    public List<List<E>> getPages() {
+        if (this.pages == null) {
+            synchronized (this) {
+                if (this.pages != null) {
+                    return this.pages;
+                }
+
+                List<List<E>> pages = Lists.newArrayList();
+                pages.add(Lists.newArrayList());
+                int[] columnLengths = new int[columns.length];
+                for (E element : elements) {
+                    boolean columnOverflowed = false;
+                    int[] elementColLengths = new int[columns.length];
+                    for (int colIdx = 0; colIdx < columns.length; colIdx++) {
+                        Column<E> column = columns[colIdx];
+                        String columnValue = column.getDisplayFunc().apply(element);
+                        elementColLengths[colIdx] = columnValue.length();
+                        // the current length of the colum plus the field to be added, including all newline characters (1 per field)
+                        int currentPageSize = pages.getLast().size();
+                        int colLenWithEl = columnValue.length() + columnLengths[colIdx] + currentPageSize;
+                        // do not exceed embed field limit of 1000 characters, also limit to 25 items per page
+                        if (colLenWithEl >= 1000 || currentPageSize == 25) {
+                            if (!columnOverflowed) {
+                                pages.add(Lists.newArrayList(element));
+                                columnOverflowed = true;
+                            }
+                        }
+                    }
+                    if (columnOverflowed) {
+                        columnLengths = elementColLengths;
+                    } else {
+                        pages.getLast().add(element);
+                        for (int colIdx = 0; colIdx < columns.length; colIdx++) {
+                            columnLengths[colIdx] += elementColLengths[colIdx];
+                        }
+                    }
+                }
+                this.pages = pages;
+            }
+        }
+        return this.pages;
+    }
+
+    @Override
+    protected Column<E>[] getColumns() {
+        return columns;
+    }
+
+    @Override
+    protected String getTitle() {
+        return title;
+    }
+
+    @Nullable
+    @Override
+    protected String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/command/widget/EmbedTablePaginationWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/EmbedTablePaginationWidget.java
@@ -1,0 +1,69 @@
+package net.robinfriedli.aiode.command.widget;
+
+import java.util.List;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.robinfriedli.aiode.util.EmbedTable;
+
+public abstract class EmbedTablePaginationWidget<E> extends AbstractPaginationWidget<E> {
+
+    public EmbedTablePaginationWidget(WidgetRegistry widgetRegistry, Guild guild, MessageChannel channel, List<E> elements, int pageSize) {
+        super(widgetRegistry, guild, channel, elements, pageSize);
+    }
+
+    public EmbedTablePaginationWidget(WidgetRegistry widgetRegistry, Guild guild, MessageChannel channel, List<List<E>> pages) {
+        super(widgetRegistry, guild, channel, pages);
+    }
+
+    protected abstract Column<E>[] getColumns();
+
+    @Override
+    protected void handlePage(EmbedBuilder embedBuilder, List<E> page) {
+        EmbedTable embedTable = new EmbedTable(embedBuilder);
+        for (Column<E> column : getColumns()) {
+            Function<E, EmbedTable.Group> groupFunction = column.getGroupFunction();
+            if (groupFunction != null) {
+                embedTable.addColumn(column.getTitle(), page, column.getDisplayFunc(), groupFunction);
+            } else {
+                embedTable.addColumn(column.getTitle(), page, column.getDisplayFunc());
+            }
+        }
+        embedTable.build();
+    }
+
+    public static class Column<E> {
+
+        private final String title;
+        private final Function<E, String> displayFunc;
+        @Nullable
+        private final Function<E, EmbedTable.Group> groupFunction;
+
+        public Column(String title, Function<E, String> displayFunc) {
+            this(title, displayFunc, null);
+        }
+
+        public Column(String title, Function<E, String> displayFunc, @Nullable Function<E, EmbedTable.Group> groupFunction) {
+            this.title = title;
+            this.displayFunc = displayFunc;
+            this.groupFunction = groupFunction;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public Function<E, String> getDisplayFunc() {
+            return displayFunc;
+        }
+
+        @Nullable
+        public Function<E, EmbedTable.Group> getGroupFunction() {
+            return groupFunction;
+        }
+    }
+}

--- a/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PermissionListPaginationWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PermissionListPaginationWidget.java
@@ -8,14 +8,14 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.robinfriedli.aiode.command.PermissionTarget;
 import net.robinfriedli.aiode.command.SecurityManager;
-import net.robinfriedli.aiode.command.widget.AbstractPaginationWidget;
+import net.robinfriedli.aiode.command.widget.EmbedTablePaginationWidget;
 import net.robinfriedli.aiode.command.widget.WidgetRegistry;
 import net.robinfriedli.aiode.entities.AccessConfiguration;
 import net.robinfriedli.aiode.util.EmbedTable;
 import net.robinfriedli.stringlist.StringList;
 import org.jetbrains.annotations.Nullable;
 
-public class PermissionListPaginationWidget extends AbstractPaginationWidget.EmbedTablePaginationWidget<PermissionTarget> {
+public class PermissionListPaginationWidget extends EmbedTablePaginationWidget<PermissionTarget> {
 
     private final SecurityManager securityManager;
 

--- a/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PlaylistPaginationWidget.java
+++ b/src/main/java/net/robinfriedli/aiode/command/widget/widgets/PlaylistPaginationWidget.java
@@ -1,0 +1,88 @@
+package net.robinfriedli.aiode.command.widget.widgets;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.sharding.ShardManager;
+import net.robinfriedli.aiode.Aiode;
+import net.robinfriedli.aiode.boot.SpringPropertiesConfig;
+import net.robinfriedli.aiode.command.widget.DynamicEmbedTablePaginationWidget;
+import net.robinfriedli.aiode.command.widget.WidgetRegistry;
+import net.robinfriedli.aiode.entities.Playlist;
+import net.robinfriedli.aiode.entities.PlaylistItem;
+import net.robinfriedli.aiode.util.Util;
+
+public class PlaylistPaginationWidget extends DynamicEmbedTablePaginationWidget<PlaylistItem> {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Playlist playlist;
+
+    public PlaylistPaginationWidget(
+        WidgetRegistry widgetRegistry,
+        Guild guild,
+        MessageChannel channel,
+        Playlist playlist
+    ) {
+        super(
+            widgetRegistry,
+            guild,
+            channel,
+            playlist.getName(),
+            null,
+            new Column[]{
+                new Column<>("Track", PlaylistItem::display),
+                new Column<PlaylistItem>("Duration", playlistItem -> Util.normalizeMillis(playlistItem.getDuration()))
+            },
+            playlist.getItemsSorted()
+        );
+        this.playlist = playlist;
+    }
+
+    @Override
+    protected EmbedBuilder prepareEmbedBuilder() {
+        String createdUserId = playlist.getCreatedUserId();
+        String createdUser;
+        if (createdUserId.equals("system")) {
+            createdUser = playlist.getCreatedUser();
+        } else {
+            ShardManager shardManager = Aiode.get().getShardManager();
+            User userById;
+            try {
+                userById = shardManager.retrieveUserById(createdUserId).complete();
+            } catch (Exception e) {
+                if (!(e instanceof ErrorResponseException errorResponseException && errorResponseException.getErrorResponse() == ErrorResponse.UNKNOWN_USER)) {
+                    logger.error(String.format("Failed to load createdUser of playlist %d with user id %s", playlist.getPk(), createdUserId), e);
+                }
+                userById = null;
+            }
+            createdUser = userById != null ? userById.getName() : playlist.getCreatedUser();
+        }
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.addField("Duration", Util.normalizeMillis(playlist.getDuration()), true);
+        embedBuilder.addField("Created by", createdUser, true);
+        embedBuilder.addField("Tracks", String.valueOf(playlist.getSize()), true);
+
+        SpringPropertiesConfig springPropertiesConfig = Aiode.get().getSpringPropertiesConfig();
+        String baseUri = springPropertiesConfig.requireApplicationProperty("aiode.server.base_uri");
+        String url = baseUri +
+            String.format("/list?name=%s&guildId=%s", URLEncoder.encode(playlist.getName(), StandardCharsets.UTF_8), playlist.getGuildId());
+        embedBuilder.addField("Full list", "[view online](" + url + ")", false);
+
+        embedBuilder.addBlankField(false);
+
+        embedBuilder.setThumbnail(baseUri + "/resources-public/img/aiode-logo.png");
+
+        return embedBuilder;
+    }
+}

--- a/src/main/resources/xml-contributions/widgets.xml
+++ b/src/main/resources/xml-contributions/widgets.xml
@@ -37,4 +37,20 @@
       <widgetAction identifier="lastPage" emojiUnicode="⏭" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.LastPageAction"/>
     </action-row>
   </widget>
+  <widget allowMultipleActive="true" keepMessageOnDestroy="true" implementation="net.robinfriedli.aiode.command.widget.DynamicEmbedTablePaginationWidget">
+    <action-row>
+      <widgetAction identifier="firstPage" emojiUnicode="⏮" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.FirstPageAction"/>
+      <widgetAction identifier="prevPage" emojiUnicode="⏪" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.PrevPageAction"/>
+      <widgetAction identifier="nextPage" emojiUnicode="⏩" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.NextPageAction"/>
+      <widgetAction identifier="lastPage" emojiUnicode="⏭" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.LastPageAction"/>
+    </action-row>
+  </widget>
+  <widget allowMultipleActive="true" keepMessageOnDestroy="true" implementation="net.robinfriedli.aiode.command.widget.widgets.PlaylistPaginationWidget">
+    <action-row>
+      <widgetAction identifier="firstPage" emojiUnicode="⏮" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.FirstPageAction"/>
+      <widgetAction identifier="prevPage" emojiUnicode="⏪" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.PrevPageAction"/>
+      <widgetAction identifier="nextPage" emojiUnicode="⏩" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.NextPageAction"/>
+      <widgetAction identifier="lastPage" emojiUnicode="⏭" resetRequired="true" displayPredicate="widget.getPages().size() > 1" implementation="net.robinfriedli.aiode.command.widget.actions.LastPageAction"/>
+    </action-row>
+  </widget>
 </widgets>


### PR DESCRIPTION
- implement DynamicEmbedTablePaginationWidget to dynamically break an EmbedTable into pages depending on how many items fit on a page without overflowing a column
- adjust PresetCommand, AbstractScriptCommand, SearchCommand
- improve EmbedTable to split all columns if one of the columns overflows into a new field so that they stay aligned