### PR TITLE
replace jda-nas with udpqueue.rs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
 
     maven {
         url = "https://jitpack.io"
@@ -41,7 +40,6 @@ dependencies {
 
     implementation "com.google.apis:google-api-services-youtube:v3-rev20240417-2.0.0"
     implementation 'com.google.guava:guava:33.1.0-jre'
-    implementation "com.sedmelluq:jda-nas:1.1.0"
     implementation "dev.arbjerg:lavaplayer:2.2.1"
     implementation "dev.arbjerg:lavaplayer-ext-youtube-rotator:2.2.1"
     implementation "dev.lavalink.youtube:common:1.5.2"
@@ -63,6 +61,16 @@ dependencies {
     implementation "com.github.robinfriedli:JXP:2.0.5"
     implementation "com.github.robinfriedli:StringList:1.6.1"
     implementation "com.github.robinfriedli:ThreadPool:1.2.0"
+
+    implementation("club.minnced:udpqueue-native-linux-x86-64:0.2.9")
+    implementation("club.minnced:udpqueue-native-linux-x86:0.2.9")
+    implementation("club.minnced:udpqueue-native-linux-aarch64:0.2.9")
+    implementation("club.minnced:udpqueue-native-linux-arm:0.2.9")
+    implementation("club.minnced:udpqueue-native-linux-musl-x86-64:0.2.9")
+    implementation("club.minnced:udpqueue-native-linux-musl-aarch64:0.2.9")
+    implementation("club.minnced:udpqueue-native-win-x86-64:0.2.9")
+    implementation("club.minnced:udpqueue-native-win-x86:0.2.9")
+    implementation("club.minnced:udpqueue-native-darwin:0.2.9")
 
     implementation "org.apache.commons:commons-collections4:4.4"
     implementation "org.apache.commons:commons-text:1.12.0"

--- a/src/main/java/net/robinfriedli/aiode/boot/configurations/JdaComponent.java
+++ b/src/main/java/net/robinfriedli/aiode/boot/configurations/JdaComponent.java
@@ -111,8 +111,16 @@ public class JdaComponent {
     public static boolean platformSupportsJdaNas() {
         String osName = System.getProperty("os.name").toLowerCase();
         String osArch = System.getProperty("os.arch").toLowerCase();
-        return (osName.contains("linux") || osName.contains("windows"))
-            && (osArch.contains("amd64") || osArch.contains("x86"));
+        boolean isLinux = osName.contains("linux");
+        boolean isWindows = osName.contains("windows");
+        boolean isMac = osName.contains("mac");
+        boolean isAmd = osArch.contains("amd64");
+        boolean isX86 = osArch.contains("x86");
+        boolean isAarch64 = osArch.contains("aarch64");
+        boolean isMusl = osArch.contains("musl");
+        return (isLinux && (isAmd || isX86 || isAarch64 || isMusl))
+            || (isWindows && (isAmd || isX86))
+            || (isMac && (isX86 || isAarch64));
     }
 
 }


### PR DESCRIPTION
- fixes #406
- removes the last jcenter dependency, enabling removal of deprecated repo
- enables support for new platforms mac aarch64 and x86