### PR TITLE
implement Spotify to SoundCloud redirect

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/audio/UrlPlayable.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/UrlPlayable.java
@@ -1,5 +1,6 @@
 package net.robinfriedli.aiode.audio;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -95,7 +96,7 @@ public class UrlPlayable implements Playable {
     @Nullable
     @Override
     public String getAlbumCoverUrl() {
-        return null;
+        return Optional.ofNullable(audioTrack).map(AudioTrack::getInfo).map(info -> info.artworkUrl).orElse(null);
     }
 
     @Override

--- a/src/main/java/net/robinfriedli/aiode/audio/spotify/SpotifyTrackRedirect.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/spotify/SpotifyTrackRedirect.java
@@ -1,16 +1,19 @@
 package net.robinfriedli.aiode.audio.spotify;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.google.common.base.Strings;
 import net.dv8tion.jda.api.entities.User;
 import net.robinfriedli.aiode.Aiode;
 import net.robinfriedli.aiode.audio.AbstractSoftCachedPlayable;
 import net.robinfriedli.aiode.audio.Playable;
+import net.robinfriedli.aiode.audio.UrlPlayable;
 import net.robinfriedli.aiode.audio.youtube.HollowYouTubeVideo;
 import net.robinfriedli.aiode.audio.youtube.YouTubeService;
 import net.robinfriedli.aiode.audio.youtube.YouTubeVideo;
@@ -32,6 +35,7 @@ public class SpotifyTrackRedirect extends AbstractSoftCachedPlayable {
     private final SpotifyTrack spotifyTrack;
 
     private final CompletableFuture<FilebrokerPlayableWrapper> filebrokerPost;
+    private final CompletableFuture<UrlPlayable> soundCloudTrack;
     private final HollowYouTubeVideo youTubeVideo;
 
     private volatile boolean loading = false;
@@ -40,6 +44,7 @@ public class SpotifyTrackRedirect extends AbstractSoftCachedPlayable {
     public SpotifyTrackRedirect(SpotifyTrack spotifyTrack, YouTubeService youTubeService) {
         this.spotifyTrack = spotifyTrack;
         filebrokerPost = new CompletableFuture<>();
+        soundCloudTrack = new CompletableFuture<>();
         youTubeVideo = new HollowYouTubeVideo(youTubeService, spotifyTrack);
     }
 
@@ -78,16 +83,26 @@ public class SpotifyTrackRedirect extends AbstractSoftCachedPlayable {
 
     /**
      * Complete the redirect and notify threads awaiting its completion, current thread must hold this object's monitor.
-     * Sets the redirected filebroker post to the provided one or cancels it if null, the redirected YouTube video is expected
-     * to be loaded by completing the {@link HollowYouTubeVideo} if there is no filebroker post present.
+     * Sets the redirected filebroker post or soundcloud track to the provided one or cancels it if null, the redirected YouTube video is expected
+     * to be loaded by completing the {@link HollowYouTubeVideo} if there is no filebroker post or soundcloud track present.
      *
-     * @param filebrokerPost the filebroker post the spotify track redirects to, will be cancelled if null
+     * @param playable the filebroker post or soundcloud track the spotify track redirects to, will be cancelled if null
      */
-    public void complete(@Nullable FilebrokerPlayableWrapper filebrokerPost) {
-        if (filebrokerPost != null) {
-            this.filebrokerPost.complete(filebrokerPost);
-        } else {
-            this.filebrokerPost.cancel(true);
+    public void complete(@Nullable Playable playable) {
+        switch (playable) {
+            case FilebrokerPlayableWrapper filebrokerPost -> {
+                this.filebrokerPost.complete(filebrokerPost);
+                this.soundCloudTrack.cancel(true);
+            }
+            case UrlPlayable urlPlayable -> {
+                this.filebrokerPost.cancel(true);
+                this.soundCloudTrack.complete(urlPlayable);
+            }
+            case null -> {
+                this.filebrokerPost.cancel(true);
+                this.soundCloudTrack.cancel(true);
+            }
+            default -> throw new IllegalArgumentException("Unsupported playable: " + playable);
         }
 
         loading = false;
@@ -98,27 +113,42 @@ public class SpotifyTrackRedirect extends AbstractSoftCachedPlayable {
         loading = true;
     }
 
-    private FilebrokerPlayableWrapper getCompletedFilebrokerPost() {
+    private <T> T getCompletedFuture(CompletableFuture<T> future) {
         try {
             try {
-                return filebrokerPost.get(100, TimeUnit.MILLISECONDS);
+                return future.get(100, TimeUnit.MILLISECONDS);
             } catch (TimeoutException e) {
                 fetch();
 
-                return filebrokerPost.get(3, TimeUnit.MINUTES);
+                return future.get(3, TimeUnit.MINUTES);
             }
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         } catch (TimeoutException e) {
-            throw new RuntimeException("Filebroker loading timed out", e);
+            throw new RuntimeException("Loading timed out", e);
         } catch (CancellationException e) {
             return null;
         }
     }
 
+    public FilebrokerPlayableWrapper getCompletedFilebrokerPost() {
+        return getCompletedFuture(filebrokerPost);
+    }
+
+    public UrlPlayable getCompletedSoundCloudTrack() {
+        return getCompletedFuture(soundCloudTrack);
+    }
+
     private <T> T applyToEither(CheckedFunction<Playable, T> function) {
         FilebrokerPlayableWrapper filebrokerPost = getCompletedFilebrokerPost();
-        return function.apply(Objects.requireNonNullElse(filebrokerPost, youTubeVideo));
+        if (filebrokerPost != null) {
+            return function.apply(filebrokerPost);
+        }
+        if (youTubeVideo.isDone()) {
+            return function.apply(youTubeVideo);
+        }
+        UrlPlayable soundCloudTrack = getCompletedSoundCloudTrack();
+        return function.apply(Objects.requireNonNullElse(soundCloudTrack, youTubeVideo));
     }
 
     private <T> T applyToEitherWithTimeout(long timeOut, TimeUnit unit, CheckedFunction<Playable, T> function) throws TimeoutException {
@@ -164,31 +194,49 @@ public class SpotifyTrackRedirect extends AbstractSoftCachedPlayable {
 
     @Override
     public String getTitle() throws UnavailableResourceException {
-        return applyToEither(Playable::getTitle);
+        return Optional.ofNullable(spotifyTrack.getName()).orElseGet(() -> applyToEither(Playable::getTitle));
     }
 
     @Override
     public String getTitle(long timeOut, TimeUnit unit) throws UnavailableResourceException, TimeoutException {
+        if (!Strings.isNullOrEmpty(spotifyTrack.getName())) {
+            return spotifyTrack.getName();
+        }
         return applyToEitherWithTimeout(timeOut, unit, Playable::getTitle);
     }
 
     @Override
     public String getTitleNow(String alternativeValue) {
+        if (!Strings.isNullOrEmpty(spotifyTrack.getName())) {
+            return spotifyTrack.getName();
+        }
         return applyToEitherNow(alternativeValue, Playable::getTitle);
     }
 
     @Override
     public String getDisplay() throws UnavailableResourceException {
+        String display = spotifyTrack.getDisplay();
+        if (!Strings.isNullOrEmpty(display)) {
+            return display;
+        }
         return applyToEither(Playable::getDisplay);
     }
 
     @Override
     public String getDisplay(long timeOut, TimeUnit unit) throws UnavailableResourceException, TimeoutException {
+        String display = spotifyTrack.getDisplay();
+        if (!Strings.isNullOrEmpty(display)) {
+            return display;
+        }
         return applyToEitherWithTimeout(timeOut, unit, Playable::getDisplay);
     }
 
     @Override
     public String getDisplayNow(String alternativeValue) throws UnavailableResourceException {
+        String display = spotifyTrack.getDisplay();
+        if (!Strings.isNullOrEmpty(display)) {
+            return display;
+        }
         return applyToEitherNow(alternativeValue, Playable::getDisplay);
     }
 
@@ -209,6 +257,10 @@ public class SpotifyTrackRedirect extends AbstractSoftCachedPlayable {
 
     @Override
     public @Nullable String getAlbumCoverUrl() {
+        String albumCoverUrl = spotifyTrack.getAlbumCoverUrl();
+        if (!Strings.isNullOrEmpty(albumCoverUrl)) {
+            return albumCoverUrl;
+        }
         return applyToEither(Playable::getAlbumCoverUrl);
     }
 

--- a/src/main/java/net/robinfriedli/aiode/entities/SpotifyRedirectIndex.java
+++ b/src/main/java/net/robinfriedli/aiode/entities/SpotifyRedirectIndex.java
@@ -40,6 +40,8 @@ public class SpotifyRedirectIndex implements Serializable {
     private String youTubeId;
     @Column(name = "filebroker_pk")
     private Long fileBrokerPk;
+    @Column(name = "soundcloud_uri")
+    private String soundCloudUri;
     @Column(name = "last_updated")
     private LocalDate lastUpdated;
     @Column(name = "last_used")
@@ -51,10 +53,11 @@ public class SpotifyRedirectIndex implements Serializable {
     public SpotifyRedirectIndex() {
     }
 
-    public SpotifyRedirectIndex(String spotifyId, String youTubeId, Long fileBrokerPk, SpotifyTrackKind kind, Session session) {
+    public SpotifyRedirectIndex(String spotifyId, String youTubeId, Long fileBrokerPk, String soundCloudUri, SpotifyTrackKind kind, Session session) {
         this.spotifyId = spotifyId;
         this.youTubeId = youTubeId;
         this.fileBrokerPk = fileBrokerPk;
+        this.soundCloudUri = soundCloudUri;
         lastUpdated = LocalDate.now();
         lastUsed = LocalDate.now();
         spotifyItemKind = LookupEntity.require(session, SpotifyItemKind.class, kind.name());
@@ -125,5 +128,13 @@ public class SpotifyRedirectIndex implements Serializable {
 
     public void setFileBrokerPk(Long fileBrokerPk) {
         this.fileBrokerPk = fileBrokerPk;
+    }
+
+    public String getSoundCloudUri() {
+        return soundCloudUri;
+    }
+
+    public void setSoundCloudUri(String soundCloudUri) {
+        this.soundCloudUri = soundCloudUri;
     }
 }

--- a/src/main/resources/liquibase/dbchangelog.xml
+++ b/src/main/resources/liquibase/dbchangelog.xml
@@ -1197,4 +1197,9 @@ See application.properties -> spring.liquibase.contexts
   <changeSet author="robinfriedli (generated)" id="1725414843868-5">
     <addForeignKeyConstraint baseColumnNames="assigned_private_bot_instance" baseTableName="guild_specification" constraintName="guild_specification_assigned_private_bot_instance_fkey" deferrable="false" initiallyDeferred="false" referencedColumnNames="identifier" referencedTableName="private_bot_instance" validate="true"/>
   </changeSet>
+  <changeSet author="robinfriedli (generated)" id="1725559121587-1">
+    <addColumn tableName="spotify_redirect_index">
+      <column name="soundcloud_uri" type="varchar(255)"/>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
- load SoundCloud track alongside of YouTube if no filebroker post was found
- use SoundCloud track if YouTube fails to play due to ban