### PR TITLE
always enforce GuildSpecification to be refreshed from DB

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/discord/GuildContext.java
+++ b/src/main/java/net/robinfriedli/aiode/discord/GuildContext.java
@@ -58,7 +58,9 @@ public class GuildContext {
     }
 
     public GuildSpecification getSpecification(Session session) {
-        return session.getReference(GuildSpecification.class, specificationPk);
+        GuildSpecification guildSpecification = session.getReference(GuildSpecification.class, specificationPk);
+        session.refresh(guildSpecification);
+        return guildSpecification;
     }
 
     public GuildSpecification getSpecification() {


### PR DESCRIPTION
- fixes issue where updating privateBotAssignmentLastHeartbeat would sometimes reset privateBotInstance to null because hibernate is garbage that will flush stale data